### PR TITLE
Add AllocSiteInfo analysis pass

### DIFF
--- a/include/sea_dsa/AllocSiteInfo.hh
+++ b/include/sea_dsa/AllocSiteInfo.hh
@@ -1,0 +1,58 @@
+/**
+   A pass to identify allocations sites and their sizes (if known). The
+   information is exposed metadata attached to allocation sites.
+ */
+#pragma once
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Pass.h"
+
+namespace llvm {
+class DataLayout;
+class Function;
+class LLVMContext;
+class Module;
+class Instruction;
+class TargetLibraryInfo;
+class Type;
+class Value;
+} // namespace llvm
+
+namespace sea_dsa {
+class AllocWrapInfo;
+
+class AllocSiteInfo : public llvm::ModulePass {
+  llvm::TargetLibraryInfo *m_tli;
+  const llvm::DataLayout *m_dl;
+  AllocWrapInfo *m_awi;
+
+  const llvm::StringRef m_allocSiteMetadataTag = getAllocSiteMetadataTag();
+
+  llvm::Optional<unsigned> maybeEvalAllocSize(llvm::Value &v,
+                                              llvm::LLVMContext &ctx);
+  bool markAllocs(llvm::Function &F);
+
+  void markAsAllocSite(llvm::Instruction &inst,
+                       llvm::Optional<unsigned> allocatedBytes = llvm::None);
+
+public:
+  static char ID;
+
+  AllocSiteInfo()
+      : ModulePass(ID), m_tli(nullptr), m_dl(nullptr), m_awi(nullptr) {}
+  bool runOnModule(llvm::Module &) override;
+  llvm::StringRef getPassName() const override {
+    return "Allocation Site Identification pass";
+  }
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+
+  static llvm::StringRef getAllocSiteMetadataTag() {
+    return "sea.dsa.allocsite";
+  };
+
+  static bool isAllocSite(const llvm::Value &v);
+  static llvm::Optional<unsigned>
+  getAllocSiteSize(const llvm::Value &v);
+};
+} // namespace sea_dsa

--- a/include/sea_dsa/TypeUtils.hh
+++ b/include/sea_dsa/TypeUtils.hh
@@ -11,6 +11,8 @@ class Type;
 
 namespace sea_dsa {
 
+unsigned getTypeSizeInBytes(const llvm::Type &ty, const llvm::DataLayout &dl);
+
 struct SubTypeDesc {
   llvm::Type *Ty = nullptr;
   unsigned Bytes = 0;

--- a/src/AllocSiteInfo.cc
+++ b/src/AllocSiteInfo.cc
@@ -1,0 +1,160 @@
+#include "sea_dsa/AllocSiteInfo.hh"
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Value.h"
+
+#include "llvm/Analysis/MemoryBuiltins.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Debug.h"
+
+#include "sea_dsa/AllocWrapInfo.hh"
+#include "sea_dsa/TypeUtils.hh"
+#include "sea_dsa/support/Debug.h"
+
+#define ASI_LOG(...) LOG("alloc_site_info", __VA_ARGS__)
+// #define ASI_LOG(...) do { __VA_ARGS__ ; } while (false)
+
+using namespace sea_dsa;
+using namespace llvm;
+
+char AllocSiteInfo::ID = 0;
+
+static MDNode *mkMetaConstant(llvm::Optional<unsigned> val, LLVMContext &ctx) {
+  MDNode *meta = MDNode::get(ctx, llvm::None);
+  if (val.hasValue())
+    meta = MDNode::get(ctx, ConstantAsMetadata::get(ConstantInt::get(
+                                ctx, llvm::APInt(64u, size_t(*val)))));
+  return meta;
+}
+
+void AllocSiteInfo::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<TargetLibraryInfoWrapperPass>();
+  AU.addRequired<AllocWrapInfo>();
+  AU.setPreservesAll();
+}
+
+bool AllocSiteInfo::runOnModule(Module &M) {
+  m_tli = &getAnalysis<TargetLibraryInfoWrapperPass>().getTLI();
+  m_dl = &M.getDataLayout();
+  m_awi = &getAnalysis<AllocWrapInfo>();
+
+  bool changed = false;
+
+  // Handle alloc sites inside functions.
+  for (auto &fn : M) {
+    if (fn.isDeclaration())
+      continue;
+
+    ASI_LOG(llvm::errs() << "Running AllocSiteInfo pass on function "
+                         << fn.getName() << "\n");
+    changed |= markAllocs(fn);
+  }
+
+  // Handle global variables with initializers.
+  for (auto &gv : M.globals()) {
+    if (gv.hasDefinitiveInitializer()) {
+      auto sz = maybeEvalAllocSize(gv, M.getContext());
+      MDNode *meta = mkMetaConstant(sz, M.getContext());
+      gv.setMetadata(m_allocSiteMetadataTag, meta);
+      changed = true;
+    }
+  }
+
+  // TODO(Jakub): what about formals?
+
+  return changed;
+}
+
+Optional<unsigned> AllocSiteInfo::maybeEvalAllocSize(Value &v,
+                                                     LLVMContext &ctx) {
+  llvm::Optional<unsigned> bytes = llvm::None;
+
+  llvm::ObjectSizeOpts Opts;
+  Opts.RoundToAlign = true;
+  Opts.EvalMode = llvm::ObjectSizeOpts::Mode::Max;
+  ObjectSizeOffsetVisitor OSOV(*m_dl, m_tli, ctx, Opts);
+  auto OffsetAlign = OSOV.compute(&v);
+  if (OSOV.knownSize(OffsetAlign)) {
+    const int64_t sz = OffsetAlign.first.getSExtValue();
+    assert(sz > 0);
+    bytes = unsigned(sz);
+  }
+
+  return bytes;
+}
+
+void AllocSiteInfo::markAsAllocSite(Instruction &inst,
+                                    Optional<unsigned> allocatedBytes) {
+  MDNode *meta = mkMetaConstant(allocatedBytes, inst.getContext());
+  inst.setMetadata(m_allocSiteMetadataTag, meta);
+}
+
+/// Adds metadata to all known allocating instructions.
+/// For allocations of known size, the number of allocated bytes is saved in
+/// metadata.
+bool AllocSiteInfo::markAllocs(Function &F) {
+  bool changed = false;
+  for (auto &bb : F)
+    for (auto &inst : bb) {
+      if (auto *ai = dyn_cast<AllocaInst>(&inst)) {
+        unsigned bytes = getTypeSizeInBytes(*ai->getAllocatedType(), *m_dl);
+        markAsAllocSite(*ai, bytes);
+        changed = true;
+        continue;
+      }
+
+      if (auto *ci = dyn_cast<CallInst>(&inst)) {
+        if (auto *callee = ci->getCalledFunction()) {
+          if (m_awi->isAllocWrapper(*callee)) {
+            Optional<unsigned> bytes = maybeEvalAllocSize(*ci, F.getContext());
+            markAsAllocSite(*ci, bytes);
+            changed = true;
+          }
+        }
+      }
+    }
+
+  return changed;
+}
+
+bool AllocSiteInfo::isAllocSite(const Value &v) {
+  if (auto *inst = dyn_cast<Instruction>(&v))
+    return inst->getMetadata(getAllocSiteMetadataTag());
+
+  if (auto *gv = dyn_cast<GlobalVariable>(&v))
+    return gv->getMetadata(getAllocSiteMetadataTag());
+
+  return false;
+}
+
+llvm::Optional<unsigned> AllocSiteInfo::getAllocSiteSize(const Value &v) {
+  assert(isAllocSite(v) && "Check if it's an alloc site first!");
+  MDNode *meta = nullptr;
+  if (auto *inst = dyn_cast<Instruction>(&v))
+    meta = inst->getMetadata(getAllocSiteMetadataTag());
+  else if (auto *gv = dyn_cast<GlobalVariable>(&v))
+    meta = gv->getMetadata(getAllocSiteMetadataTag());
+  else
+    llvm_unreachable("Wrong value type?");
+
+  assert(meta);
+
+  if (meta->getNumOperands() > 0)
+    if (auto *c = dyn_cast<ConstantAsMetadata>(meta->getOperand(0))) {
+      Constant *val = c->getValue();
+      assert(val);
+      assert(isa<ConstantInt>(val));
+      auto *valInt = cast<ConstantInt>(val);
+      return unsigned(valInt->getLimitedValue());
+    }
+
+  return llvm::None;
+}
+
+static llvm::RegisterPass<sea_dsa::AllocSiteInfo> X("seadsa-alloc-site-info",
+                                                    "Detects allocation sites");

--- a/src/AllocWrapInfo.cc
+++ b/src/AllocWrapInfo.cc
@@ -1,14 +1,12 @@
 #include "sea_dsa/AllocWrapInfo.hh"
 
+#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/MemoryBuiltins.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Value.h"
-
-#include "llvm/Analysis/LoopInfo.h"
-#include "llvm/Analysis/MemoryBuiltins.h"
 
 #include <vector>
 
@@ -99,6 +97,7 @@ void AllocWrapInfo::findAllocs(Module &M) {
     }
   }
 }
+
 bool AllocWrapInfo::isAllocWrapper(llvm::Function &fn) const {
   return m_allocs.count(fn.getName()) != 0;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,5 +18,6 @@ add_llvm_library (SeaDsaAnalysis
   NameValues.cc
   RemovePtrToInt.cc
   AllocWrapInfo.cc
+  AllocSiteInfo.cc
   DsaAllocSite.cc
   )

--- a/src/TypeUtils.cc
+++ b/src/TypeUtils.cc
@@ -12,6 +12,11 @@
 
 using namespace llvm;
 
+unsigned sea_dsa::getTypeSizeInBytes(const Type &ty, const DataLayout &dl) {
+  unsigned sz = dl.getTypeSizeInBits(&const_cast<Type &>(ty));
+  return sz < 8 ? 1 : sz / 8;
+}
+
 namespace sea_dsa {
 
 void SubTypeDesc::dump(llvm::raw_ostream &OS /* = llvm::errs() */) {
@@ -26,9 +31,10 @@ void SubTypeDesc::dump(llvm::raw_ostream &OS /* = llvm::errs() */) {
 
 unsigned AggregateIterator::sizeInBytes(Type *Ty) const {
   // Don't track offsets when DL is not available.
-  const auto Bits = DL ? DL->getTypeSizeInBits(Ty) : 0;
-  assert(!DL || Bits >= 8);
-  return Bits / 8;
+  if (!DL)
+    return 0;
+
+  return getTypeSizeInBytes(*Ty, *DL);
 }
 
 void AggregateIterator::doStep() {


### PR DESCRIPTION
I noticed we have the same code (to check whether an instruction is an allocator, and if so, what is the size of the allocated object) in multiple places in SeaDsa and SeaHorn.

This pass computes the allocation site info, as understood by SeaDsa, and embeds the results in metadata -- I find it much easier to debug this way.