### PR TITLE
Fix issue129

### DIFF
--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -1513,14 +1513,17 @@ bool transfersNoPointers(MemTransferInst &MI, const DataLayout &DL) {
   const uint64_t length = rawLength->getZExtValue();
   LOG("dsa", errs() << "MemTransfer length:\t" << length << "\n");
 
+  // opaque structs may transfer pointers
+  if (!srcTy->isSized()) return false;
+
   // TODO: Go up to the GEP chain to find nearest fitting type to transfer.
   // This can occur when someone tries to transfer int the middle of a struct.
-  if (!srcTy->isSized() || length * 8 > DL.getTypeSizeInBits(srcTy)) {
+  if (length * 8 > DL.getTypeSizeInBits(srcTy)) {
     LOG("dsa-warn", errs() << "WARNING: MemTransfer past object size!\n"
                            << "\tTransfer:  ");
     LOG("dsa", MI.print(errs()));
     LOG("dsa-warn", errs() << "\n\tLength:  " << length << "\n\tType size:  "
-                           << (srcTy->isSized()? (DL.getTypeSizeInBits(srcTy) / 8) : 0) << "\n");
+                           << (DL.getTypeSizeInBits(srcTy) / 8) << "\n");
     return false;
   }
 

--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -1515,12 +1515,12 @@ bool transfersNoPointers(MemTransferInst &MI, const DataLayout &DL) {
 
   // TODO: Go up to the GEP chain to find nearest fitting type to transfer.
   // This can occur when someone tries to transfer int the middle of a struct.
-  if (length * 8 > DL.getTypeSizeInBits(srcTy)) {
+  if (!srcTy->isSized() || length * 8 > DL.getTypeSizeInBits(srcTy)) {
     LOG("dsa-warn", errs() << "WARNING: MemTransfer past object size!\n"
                            << "\tTransfer:  ");
     LOG("dsa", MI.print(errs()));
     LOG("dsa-warn", errs() << "\n\tLength:  " << length << "\n\tType size:  "
-                           << (DL.getTypeSizeInBits(srcTy) / 8) << "\n");
+                           << (srcTy->isSized()? (DL.getTypeSizeInBits(srcTy) / 8) : 0) << "\n");
     return false;
   }
 


### PR DESCRIPTION
Fix for issue #129 
Added a check on `srcTy->isSized()` so that `transfersNoPointers` returns false in case of opaque structs as well, without crashing. Not sure if the warning should be emitted, or the check should be in a separate condition, just before.