### PR TITLE
Fixed various warnings generated by Clang-12

### DIFF
--- a/include/seadsa/GraphTraits.hh
+++ b/include/seadsa/GraphTraits.hh
@@ -30,6 +30,8 @@ namespace seadsa {
     
     bool operator!=(const this_type& x) const { return !operator==(x); }
     
+    NodeIterator(const NodeIterator&) = default;
+
     const this_type &operator=(const this_type &o) {
       _links_it = o._links_it;
       return *this;

--- a/include/seadsa/TypeUtils.hh
+++ b/include/seadsa/TypeUtils.hh
@@ -33,7 +33,7 @@ class AggregateIterator {
   SubTypeDesc Current;
 
   AggregateIterator(const llvm::DataLayout *DL_, llvm::Type *Ty_) : DL(DL_) {
-    Worklist.push_back({Ty_});
+    Worklist.push_back(Ty_);
   }
 
 public:

--- a/include/seadsa/support/NameValues.hh
+++ b/include/seadsa/support/NameValues.hh
@@ -10,10 +10,10 @@ namespace seadsa {
 struct NameValues : public llvm::ModulePass {
   static char ID;
   NameValues() : llvm::ModulePass(ID) {}
-  bool runOnModule(llvm::Module &M);
+  bool runOnModule(llvm::Module &M) override;
   bool runOnFunction(llvm::Function &F);
-  void getAnalysisUsage(llvm::AnalysisUsage &AU) const { AU.setPreservesAll(); }
-  virtual llvm::StringRef getPassName() const {
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override { AU.setPreservesAll(); }
+  virtual llvm::StringRef getPassName() const override {
     return "sea-dsa: names all unnamed values";
   }
 };

--- a/lib/seadsa/DsaColor.cc
+++ b/lib/seadsa/DsaColor.cc
@@ -29,7 +29,6 @@ void color_nodes_aux(const Node &n_callee, const Node &n_caller,
   c_callee.insert({&n_callee, col});
 
   for (auto &links : n_callee.getLinks()) {
-    const Field &f = links.first;
     const Cell &next_c_callee = *links.second;
     const Node *next_n_callee = next_c_callee.getNode();
     const Cell &next_c_caller = sm.get(next_c_callee);

--- a/lib/seadsa/DsaCompleteCallGraph.cc
+++ b/lib/seadsa/DsaCompleteCallGraph.cc
@@ -347,8 +347,6 @@ CompleteCallGraphAnalysis::CompleteCallGraphAnalysis(
 
 bool CompleteCallGraphAnalysis::runOnModule(Module &M) {
 
-  typedef std::unordered_set<const Instruction *> InstSet;
-
   LOG("dsa-callgraph",
       errs() << "Started construction of complete call graph ... \n");
 

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -296,8 +296,8 @@ ContextSensitiveGlobalAnalysis::ContextSensitiveGlobalAnalysis(
     const AllocWrapInfo &allocInfo, const DsaLibFuncInfo &dsaLibFuncInfo,
     llvm::CallGraph &cg, SetFactory &setFactory, bool storeSummaryGraphs)
     : GlobalAnalysis(GlobalAnalysisKind::CONTEXT_SENSITIVE), m_dl(dl),
-      m_tliWrapper(tliWrapper), m_allocInfo(allocInfo), m_cg(cg),
-      m_dsaLibFuncInfo(dsaLibFuncInfo), m_setFactory(setFactory),
+      m_tliWrapper(tliWrapper), m_allocInfo(allocInfo),
+      m_dsaLibFuncInfo(dsaLibFuncInfo), m_cg(cg), m_setFactory(setFactory),
       m_store_bu_graphs(storeSummaryGraphs) {}
 
 bool ContextSensitiveGlobalAnalysis::checkAllNodesAreMapped(

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -63,8 +63,6 @@ void ContextInsensitiveGlobalAnalysis::resolveArguments(
   auto calleeSpec =
       dlfi.hasSpecFunc(*callee) ? dlfi.getSpecFunc(*callee) : callee;
 
-  auto name = calleeSpec->getName();
-
   if (g.hasRetCell(*calleeSpec)) {
     Cell &nc = g.mkCell(*cs.getInstruction(), Cell());
     const Cell &r = g.getRetCell(*calleeSpec);

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -283,7 +283,7 @@ std::unique_ptr<Graph> cloneGraph(const llvm::DataLayout &dl,
                                   Graph::SetFactory &sf, const Graph &g) {
   std::unique_ptr<Graph> new_g(new Graph(dl, sf, g.isFlat()));
   new_g->import(g, true /*copy all parameters*/);
-  return std::move(new_g);
+  return new_g;
 }
 
 //////

--- a/lib/seadsa/DsaLibFuncInfo.cc
+++ b/lib/seadsa/DsaLibFuncInfo.cc
@@ -196,8 +196,6 @@ void DsaLibFuncInfo::generateSpec(const llvm::Function &F,
   auto specFnExtern = m_specModule->getFunction("sea_dsa_set_external");
   auto specFnAlias = m_specModule->getFunction("sea_dsa_alias");
   auto specFnMk = m_specModule->getFunction("sea_dsa_mk");
-  auto specFnLink = m_specModule->getFunction("sea_dsa_link");
-  auto specFnAccess = m_specModule->getFunction("sea_dsa_access");
 
   if (F.getName() == "main") return;
   if (F.isDeclaration() || F.empty()) return;
@@ -270,9 +268,6 @@ void DsaLibFuncInfo::generateSpec(const llvm::Function &F,
     if (gNode->isIntToPtr()) { builder.CreateCall(specFnI2P, bitCastVal); }
     if (gNode->isExternal()) { builder.CreateCall(specFnExtern, bitCastVal); }
   };
-
-  auto FI = G->formal_begin();
-  auto FE = G->formal_end();
 
   std::stack<std::pair<Node *, Value *>> visitStack;
   llvm::DenseMap<Node *, Value *> aliasMap;

--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -710,6 +710,7 @@ void IntraBlockBuilder::visitLoadInst(LoadInst &LI) {
     }
 
     auto &c = m_graph.mkCell(LI, base.getLink(LoadedField));
+    (void)c;
     assert(!c.isNull());
   }
 

--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -731,7 +731,6 @@ void IntraBlockBuilder::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
 
   if (!m_graph.hasCell(*I.getPointerOperand()->stripPointerCasts())) { return; }
   Value *Ptr = I.getPointerOperand();
-  Value *Cmp = I.getCompareOperand();
   Value *New = I.getNewValOperand();
 
   Cell PtrC = valueCell(*Ptr);
@@ -769,7 +768,6 @@ void IntraBlockBuilder::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
 /// return OldVal
 void IntraBlockBuilder::visitAtomicRMWInst(AtomicRMWInst &I) {
   Value *Ptr = I.getPointerOperand();
-  Value *Val = I.getValOperand();
 
   seadsa::Cell PtrC = valueCell(*Ptr);
   assert(!PtrC.isNull());

--- a/lib/seadsa/Graph.cc
+++ b/lib/seadsa/Graph.cc
@@ -219,7 +219,7 @@ void Node::addAccessedType(unsigned off, llvm::Type *type) {
         tmp.push_back({o + i * sz, elementTy});
 
       workList.insert(workList.end(), tmp.rbegin(), tmp.rend());
-    } else if (const VectorType *vty = dyn_cast<const VectorType>(t)) {
+    } else if (const FixedVectorType *vty = dyn_cast<const FixedVectorType>(t)) {
       uint64_t sz = vty->getElementType()->getPrimitiveSizeInBits() / 8;
       WorkList tmp;
       const size_t numElements(vty->getNumElements());

--- a/lib/seadsa/SeaDsaAliasAnalysis.cc
+++ b/lib/seadsa/SeaDsaAliasAnalysis.cc
@@ -138,7 +138,6 @@ llvm::AliasResult SeaDsaAAResult::alias(const llvm::MemoryLocation &LocA,
 
   if (ValA == ValB) { return MustAlias; }
 
-  const DataLayout *dl = nullptr;
   // Run seadsa if we have not done it yet
   if (!m_dsa) {
     if (Module *M = getModuleFromQuery(ValA, ValB)) {

--- a/lib/seadsa/SeaMemorySSA.cc
+++ b/lib/seadsa/SeaMemorySSA.cc
@@ -67,7 +67,7 @@ public:
 
   void emitInstructionAnnot(const Instruction *I,
                             llvm::formatted_raw_ostream &OS) override {
-    const BasicBlock *BB = I->getParent();
+    // const BasicBlock *BB = I->getParent();
     if (auto *RI = dyn_cast<ReturnInst>(I)) {
       for (auto &MA : SMSSA->liveOnExit())
         OS << "; " << MA << "\n";

--- a/lib/seadsa/ShadowMem.cc
+++ b/lib/seadsa/ShadowMem.cc
@@ -461,7 +461,6 @@ class ShadowMemImpl : public InstVisitor<ShadowMemImpl> {
 
   void markUseCall(CallInst *ci, llvm::Optional<unsigned> accessedBytes) {
     assert(m_llvmCtx);
-    Module *m = ci->getModule();
     MDNode *meta = MDNode::get(*m_llvmCtx, None);
     ci->setMetadata(m_metadataTag, meta);
     ci->setMetadata(m_memUseTag, mkMetaConstant(accessedBytes));
@@ -871,7 +870,6 @@ bool ShadowMemImpl::runOnFunction(Function &F) {
   this->visit(F);
 
   auto &B = *m_B;
-  auto &ctx = *m_llvmCtx;
   auto &G = *m_graph;
   // -- compute pseudo-functions for inputs and outputs
 


### PR DESCRIPTION
This is not a complete fix, meaning there are still a few warnings pending, which I think need more thinking. In the meanwhile, I followed the compiler's suggestion to fix `-Wpessimizing-move` (dee7ef9), which removes a call to `std::move`. SeaDsa's regressions, as well as SMACK's, look fine but it would be great if you could double-check it.