### PR TITLE
refactor(printer): move class definition to header file

### DIFF
--- a/include/seadsa/Printer.hh
+++ b/include/seadsa/Printer.hh
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "llvm/IR/Module.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Module.h"
 
 #include "seadsa/CompleteCallGraph.hh"
 #include "seadsa/Global.hh"
@@ -12,39 +12,39 @@ namespace seadsa {
 
 class DsaPrinterImpl;
 
-/** 
+/**
  * Print seadsa graphs in dot format.
- * 
+ *
  * If the analysis is context-sensitive then the _global_ seadsa graph
  * of each function FUN is printed in the file FUN.mem.dot. If the
  * analysis is context-insensitive then only one _global_ seadsa graph
  * is printed for the main function. By global, we mean the results of
- * the corresponding analysis upon completion. In addition, 
+ * the corresponding analysis upon completion. In addition,
  * summaries graphs are printed if printSummaryGraphs is enabled.
  **/
 class DsaPrinter {
   std::unique_ptr<DsaPrinterImpl> m_impl;
+
 public:
   DsaPrinter(GlobalAnalysis &dsa, CompleteCallGraph *ccg,
-	     bool printSummaryGraphs = false);
+             bool printSummaryGraphs = false);
 
   ~DsaPrinter();
 
   bool runOnModule(llvm::Module &M);
 };
 
-
 class DsaPrinterPass : public llvm::ModulePass {
-public :
+public:
   static char ID;
-  
+
   DsaPrinterPass();
 
   bool runOnModule(llvm::Module &M) override;
 
   void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
-  
+
   llvm::StringRef getPassName() const override;
 };
 
-} //end namespace seadsa
+} // end namespace seadsa

--- a/include/seadsa/Printer.hh
+++ b/include/seadsa/Printer.hh
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "llvm/IR/Module.h"
+#include "llvm/ADT/StringRef.h"
+
+#include "seadsa/CompleteCallGraph.hh"
+#include "seadsa/Global.hh"
+
+#include <memory>
+
+namespace seadsa {
+
+class DsaPrinterImpl;
+
+/** 
+ * Print seadsa graphs in dot format.
+ * 
+ * If the analysis is context-sensitive then the _global_ seadsa graph
+ * of each function FUN is printed in the file FUN.mem.dot. If the
+ * analysis is context-insensitive then only one _global_ seadsa graph
+ * is printed for the main function. By global, we mean the results of
+ * the corresponding analysis upon completion. In addition, 
+ * summaries graphs are printed if printSummaryGraphs is enabled.
+ **/
+class DsaPrinter {
+  std::unique_ptr<DsaPrinterImpl> m_impl;
+public:
+  DsaPrinter(GlobalAnalysis &dsa, CompleteCallGraph *ccg,
+	     bool printSummaryGraphs = false);
+
+  ~DsaPrinter();
+
+  bool runOnModule(llvm::Module &M);
+};
+
+
+class DsaPrinterPass : public llvm::ModulePass {
+public :
+  static char ID;
+  
+  DsaPrinterPass();
+
+  bool runOnModule(llvm::Module &M) override;
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+  
+  llvm::StringRef getPassName() const override;
+};
+
+} //end namespace seadsa

--- a/lib/seadsa/DsaPrinter.cc
+++ b/lib/seadsa/DsaPrinter.cc
@@ -14,6 +14,7 @@
 #include "seadsa/Info.hh"
 #include "seadsa/support/Debug.h"
 #include "seadsa/DsaColor.hh"
+#include "seadsa/Printer.hh"
 
 /*
    Convert each DSA graph to .dot file.
@@ -660,32 +661,54 @@ static bool writeGraph(Graph *G, std::string Filename, ColorMap * cm = nullptr) 
   return false;
 }
 
-struct DsaPrinter : public ModulePass {
-  static char ID;
-  DsaAnalysis *m_dsa;
-
-  DsaPrinter() : ModulePass(ID), m_dsa(nullptr) {}
-
-private:
-  int m_cs_count = 0; // to distinguish callsites
-
+class DsaPrinterImpl {
+  // -- seadsa global analysis
+  GlobalAnalysis &m_dsa;
+  // -- seadsa callgraph: it can be null.
+  CompleteCallGraph *m_ccg;
+  // -- print summary graphs
+  bool m_print_sum_graphs;
+  // 
+  
+  bool runOnFunction(Function &F) {
+    if (m_dsa.hasGraph(F)) {
+      Graph *G = &m_dsa.getGraph(F);
+      if (G->begin() != G->end()) {
+        std::string Filename = F.getName().str() + ".mem.dot";
+        writeGraph(G, Filename);
+        if (DsaColorFunctionSimDot || m_print_sum_graphs) { // simulate bu and sas graph and color
+          if (m_dsa.hasSummaryGraph(F)) {
+            Graph *buG = &m_dsa.getSummaryGraph(F);
+            ColorMap colorBuG, colorG;
+            colorGraphsFunction(F, *buG, *G, colorBuG, colorG);
+            writeGraph(buG, F.getName().str() + ".BU.mem.dot", &colorBuG);
+	    if (DsaColorFunctionSimDot) {
+	      writeGraph(G, F.getName().str() + ".TD.mem.dot", &colorG);
+	    }
+          }
+        }
+      }
+    }
+    return false;
+  }
+  
 public :
 
-  bool runOnModule(Module &M) override {
-    m_dsa = &getAnalysis<seadsa::DsaAnalysis>();
-    assert(m_dsa);
+  DsaPrinterImpl(GlobalAnalysis &dsa, CompleteCallGraph *ccg, bool printSumGraphs)
+    : m_dsa(dsa), m_ccg(ccg), m_print_sum_graphs(printSumGraphs) {}
 
-    if (m_dsa->getDsaAnalysis().kind() == GlobalAnalysisKind::CONTEXT_INSENSITIVE) {
+  bool runOnModule(Module &M)  {
+    if (m_dsa.kind() == GlobalAnalysisKind::CONTEXT_INSENSITIVE) {
       Function *main = M.getFunction("main");
-      if (main && m_dsa->getDsaAnalysis().hasGraph(*main)) {
-        Graph *G = &m_dsa->getDsaAnalysis().getGraph(*main);
+      if (main && m_dsa.hasGraph(*main)) {
+        Graph *G = &m_dsa.getGraph(*main);
         std::string Filename = main->getName().str() + ".mem.dot";
         writeGraph(G, Filename);
       }
     } else {
-      if(DsaColorCallSiteSimDot){
-        CompleteCallGraph &ccg = getAnalysis<CompleteCallGraph>();
-        llvm::CallGraph &cg = ccg.getCompleteCallGraph();
+      if(DsaColorCallSiteSimDot && m_ccg){
+	unsigned cs_count = 0;
+        llvm::CallGraph &cg = m_ccg->getCompleteCallGraph();
         for (auto it = scc_begin(&cg); !it.isAtEnd(); ++it) {
           auto &scc = *it;
           for (CallGraphNode *cgn : scc) {
@@ -695,25 +718,23 @@ public :
             }
             // -- store the simulation maps from the SCC
             for (auto &callRecord : *cgn) {
-
-              llvm::Optional<DsaCallSite> dsaCS = call_graph_utils::getDsaCallSite(callRecord);
+              llvm::Optional<DsaCallSite> dsaCS =
+		call_graph_utils::getDsaCallSite(callRecord);
               if (!dsaCS.hasValue()) {
                 continue;
               }
               DsaCallSite &cs = dsaCS.getValue();
               Function * f_caller = fn;
               const Function * f_callee = cs.getCallee();
-              Graph &callerG =
-                m_dsa->getDsaAnalysis().getGraph(*f_caller);
-              Graph &calleeG =
-                m_dsa->getDsaAnalysis().getSummaryGraph(*f_callee);
-
+              Graph &callerG = m_dsa.getGraph(*f_caller);
+              Graph &calleeG = m_dsa.getSummaryGraph(*f_callee);
               ColorMap color_callee, color_caller;
               colorGraphsCallSite(cs, calleeG, callerG, color_callee,
                                   color_caller);
               std::string FilenameBase =
+                f_caller->getParent()->getModuleIdentifier() + "." +
                 f_caller->getName().str() + "." + f_callee->getName().str() +
-                "." + std::to_string(++m_cs_count);
+                "." + std::to_string(++cs_count);
 
               writeGraph(&calleeG, FilenameBase + ".callee.mem.dot",
                          &color_callee);
@@ -724,44 +745,47 @@ public :
           }
         }
       }
-      for (auto &F : M)
+      for (auto &F : M) {
         runOnFunction(F);
-    }
-    return false;
-  }
-
-  bool runOnFunction(Function &F) {
-    GlobalAnalysis &ga = m_dsa->getDsaAnalysis();
-    if (ga.hasGraph(F)) {
-      Graph *G = &ga.getGraph(F);
-      if (G->begin() != G->end()) {
-        std::string Filename = F.getName().str() + ".mem.dot";
-        writeGraph(G, Filename);
-        if (DsaColorFunctionSimDot) { // simulate bu and sas graph and color
-          if (ga.hasSummaryGraph(F)) {
-            Graph *buG = &ga.getSummaryGraph(F);
-            ColorMap colorBuG, colorG;
-            colorGraphsFunction(F, *buG, *G, colorBuG, colorG);
-
-            writeGraph(buG, F.getName().str() + ".BU.mem.dot", &colorBuG);
-            writeGraph(G, F.getName().str() + ".TD.mem.dot", &colorG);
-          }
-        }
       }
     }
-
     return false;
   }
-
-  void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.setPreservesAll();
-    AU.addRequired<DsaAnalysis>();
-    if (DsaColorCallSiteSimDot)
-      AU.addRequired<CompleteCallGraph>();
-  }
-
-  StringRef getPassName() const override { return "SeaHorn Dsa graph printer"; }
 };
+
+DsaPrinter::DsaPrinter(GlobalAnalysis &dsa, CompleteCallGraph *ccg, bool printSumGraphs)
+  : m_impl(std::make_unique<DsaPrinterImpl>(dsa, ccg, printSumGraphs)) {}
+
+DsaPrinter::~DsaPrinter() {}
+
+bool DsaPrinter::runOnModule(Module &M) {
+  return m_impl->runOnModule(M);
+}
+
+
+DsaPrinterPass::DsaPrinterPass(): ModulePass(ID) {}
+
+bool DsaPrinterPass::runOnModule(Module &M) {
+  auto &dsa = getAnalysis<seadsa::DsaAnalysis>();
+  CompleteCallGraph *ccg = nullptr;
+  if (DsaColorCallSiteSimDot) {
+    ccg = &getAnalysis<CompleteCallGraph>();    
+  }
+  DsaPrinter printer(dsa.getDsaAnalysis(), ccg);
+  return printer.runOnModule(M);
+}
+
+void DsaPrinterPass::getAnalysisUsage(AnalysisUsage &AU) const{
+  AU.setPreservesAll();
+  AU.addRequired<DsaAnalysis>();
+  if (DsaColorCallSiteSimDot) {
+    AU.addRequired<CompleteCallGraph>();
+  }
+}
+
+StringRef DsaPrinterPass::getPassName() const{
+  return "SeaHorn Dsa graph printer";
+}
 
 // Used by Graph::writeGraph().
 void WriteDsaGraph(Graph& G, const std::string &filename) {
@@ -825,17 +849,17 @@ struct DsaViewer : public ModulePass {
 
 };
 
-char DsaPrinter::ID = 0;
+char DsaPrinterPass::ID = 0;
 char DsaViewer::ID = 0;
 
-Pass *createDsaPrinterPass() { return new seadsa::DsaPrinter(); }
+Pass *createDsaPrinterPass() { return new seadsa::DsaPrinterPass(); }
 
 Pass *createDsaViewerPass() { return new seadsa::DsaViewer(); }
 
 } // end namespace seadsa
 
-static llvm::RegisterPass<seadsa::DsaPrinter> X("seadsa-printer",
-                                                 "Print SeaDsa memory graphs");
+static llvm::RegisterPass<seadsa::DsaPrinterPass> X("seadsa-printer",
+						    "Print SeaDsa memory graphs");
 
 static llvm::RegisterPass<seadsa::DsaViewer> Y("seadsa-viewer",
                                                 "View SeaDsa memory graphs");

--- a/lib/seadsa/DsaPrinter.cc
+++ b/lib/seadsa/DsaPrinter.cc
@@ -6,15 +6,15 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/GraphWriter.h"
 
-#include "seadsa/CompleteCallGraph.hh"
 #include "seadsa/CallGraphUtils.hh"
+#include "seadsa/CompleteCallGraph.hh"
 #include "seadsa/DsaAnalysis.hh"
+#include "seadsa/DsaColor.hh"
 #include "seadsa/Global.hh"
 #include "seadsa/GraphTraits.hh"
 #include "seadsa/Info.hh"
-#include "seadsa/support/Debug.h"
-#include "seadsa/DsaColor.hh"
 #include "seadsa/Printer.hh"
+#include "seadsa/support/Debug.h"
 
 /*
    Convert each DSA graph to .dot file.
@@ -65,7 +65,7 @@ namespace internals {
 template <typename GraphType> class GraphWriter {
   raw_ostream &O;
   const GraphType &G;
-  ColorMap * m_cm = nullptr;
+  ColorMap *m_cm = nullptr;
 
   typedef DOTGraphTraits<GraphType> DOTTraits;
   typedef GraphTraits<GraphType> GTraits;
@@ -84,26 +84,24 @@ template <typename GraphType> class GraphWriter {
     for (unsigned i = 0; EI != EE && i != 64; ++EI, ++i) {
       std::string label = DTraits.getEdgeSourceLabel(Node, EI);
 
-      if (label.empty())
-        continue;
+      if (label.empty()) continue;
 
       hasEdgeSourceLabels = true;
 
-      if (i)
-        O << "|";
+      if (i) O << "|";
 
       O << "<s" << i << ">" << DOT::EscapeString(label);
     }
 
-    if (EI != EE && hasEdgeSourceLabels)
-      O << "|<s64>truncated...";
-
+    if (EI != EE && hasEdgeSourceLabels) O << "|<s64>truncated...";
 
     return hasEdgeSourceLabels;
   }
 
 public:
-  GraphWriter(raw_ostream &o, const GraphType &g, bool SN, ColorMap *cm = nullptr ) : O(o), G(g), m_cm(cm) {
+  GraphWriter(raw_ostream &o, const GraphType &g, bool SN,
+              ColorMap *cm = nullptr)
+      : O(o), G(g), m_cm(cm) {
     DTraits = DOTTraits(SN);
   }
 
@@ -131,8 +129,7 @@ public:
     else
       O << "digraph unnamed {\n";
 
-    if (DTraits.renderGraphFromBottomUp())
-      O << "\trankdir=\"BT\";\n";
+    if (DTraits.renderGraphFromBottomUp()) O << "\trankdir=\"BT\";\n";
 
     if (!Title.empty())
       O << "\tlabel=\"" << DOT::EscapeString(Title) << "\";\n";
@@ -151,8 +148,7 @@ public:
     // Loop over the graph, printing it out...
     for (node_iterator I = GTraits::nodes_begin(G), E = GTraits::nodes_end(G);
          I != E; ++I)
-      if (!isNodeHidden(*I))
-        writeNode(*I);
+      if (!isNodeHidden(*I)) writeNode(*I);
   }
 
   bool isNodeHidden(NodeType &Node) { return isNodeHidden(&Node); }
@@ -169,8 +165,7 @@ public:
     std::string NodeAttributes = DTraits.getNodeAttributes(Node, G, m_cm);
 
     O << "\tNode" << static_cast<const void *>(Node) << " [shape=record,";
-    if (!NodeAttributes.empty())
-      O << NodeAttributes << ",";
+    if (!NodeAttributes.empty()) O << NodeAttributes << ",";
     O << "label=\"{";
 
     if (!DTraits.renderGraphFromBottomUp()) {
@@ -178,12 +173,10 @@ public:
 
       // If we should include the address of the node in the label, do so now.
       std::string Id = DTraits.getNodeIdentifierLabel(Node, G);
-      if (!Id.empty())
-        O << "|" << DOT::EscapeString(Id);
+      if (!Id.empty()) O << "|" << DOT::EscapeString(Id);
 
       std::string NodeDesc = DTraits.getNodeDescription(Node, G);
-      if (!NodeDesc.empty())
-        O << "|" << DOT::EscapeString(NodeDesc);
+      if (!NodeDesc.empty()) O << "|" << DOT::EscapeString(NodeDesc);
     }
 
     std::string edgeSourceLabels;
@@ -191,13 +184,11 @@ public:
     bool hasEdgeSourceLabels = getEdgeSourceLabels(EdgeSourceLabels, Node);
 
     if (hasEdgeSourceLabels) {
-      if (!DTraits.renderGraphFromBottomUp())
-        O << "|";
+      if (!DTraits.renderGraphFromBottomUp()) O << "|";
 
       O << "{" << EdgeSourceLabels.str() << "}";
 
-      if (DTraits.renderGraphFromBottomUp())
-        O << "|";
+      if (DTraits.renderGraphFromBottomUp()) O << "|";
     }
 
     if (DTraits.renderGraphFromBottomUp()) {
@@ -205,12 +196,10 @@ public:
 
       // If we should include the address of the node in the label, do so now.
       std::string Id = DTraits.getNodeIdentifierLabel(Node, G);
-      if (!Id.empty())
-        O << "|" << DOT::EscapeString(Id);
+      if (!Id.empty()) O << "|" << DOT::EscapeString(Id);
 
       std::string NodeDesc = DTraits.getNodeDescription(Node, G);
-      if (!NodeDesc.empty())
-        O << "|" << DOT::EscapeString(NodeDesc);
+      if (!NodeDesc.empty()) O << "|" << DOT::EscapeString(NodeDesc);
     }
 
     O << "}\"];\n"; // Finish printing the "node" line
@@ -222,21 +211,17 @@ public:
                  const std::string &Label, unsigned NumEdgeSources = 0,
                  const std::vector<std::string> *EdgeSourceLabels = nullptr) {
     O << "\tNode" << ID << " [";
-    if (!Attr.empty())
-      O << Attr << ",";
+    if (!Attr.empty()) O << Attr << ",";
     O << " label =\"";
-    if (NumEdgeSources)
-      O << "{";
+    if (NumEdgeSources) O << "{";
     O << DOT::EscapeString(Label);
     if (NumEdgeSources) {
       O << "|{";
 
       for (unsigned i = 0; i != NumEdgeSources; ++i) {
-        if (i)
-          O << "|";
+        if (i) O << "|";
         O << "<s" << i << ">";
-        if (EdgeSourceLabels)
-          O << DOT::EscapeString((*EdgeSourceLabels)[i]);
+        if (EdgeSourceLabels) O << DOT::EscapeString((*EdgeSourceLabels)[i]);
       }
       O << "}}";
     }
@@ -246,17 +231,15 @@ public:
   /// emitEdge - Output an edge from a simple node into the graph...
   void emitEdge(const void *SrcNodeID, int SrcNodePort, const void *DestNodeID,
                 int DestNodePort, llvm::Twine Attrs) {
-    if (SrcNodePort > 64)
-      return; // Eminating from truncated part?
-//    if (DestNodePort > 64)
-//      DestNodePort = 64; // Targeting the truncated part?
+    if (SrcNodePort > 64) return; // Eminating from truncated part?
+                                  //    if (DestNodePort > 64)
+    //      DestNodePort = 64; // Targeting the truncated part?
 
     // Ignore DestNodePort and point to the whole node instead.
     DestNodePort = -1;
 
     O << "\tNode" << SrcNodeID;
-    if (SrcNodePort >= 0)
-      O << ":s" << SrcNodePort;
+    if (SrcNodePort >= 0) O << ":s" << SrcNodePort;
     O << " -> Node" << DestNodeID;
 
     // Edges that go to cells with zero offset do not
@@ -265,8 +248,7 @@ public:
       O << ":s" << DestNodePort;
     }
 
-    if (!Attrs.isTriviallyEmpty())
-      O << "[" << Attrs << "]";
+    if (!Attrs.isTriviallyEmpty()) O << "[" << Attrs << "]";
 
     O << ";\n";
   }
@@ -277,11 +259,10 @@ public:
 };
 
 template <typename GraphType>
-raw_ostream &WriteGraph(raw_ostream &O, const GraphType &G,
-                        ColorMap *cm, bool ShortNames = false,
-                        const Twine &Title = "") {
+raw_ostream &WriteGraph(raw_ostream &O, const GraphType &G, ColorMap *cm,
+                        bool ShortNames = false, const Twine &Title = "") {
   // Start the graph emission process...
-  GraphWriter<GraphType> W(O, G, ShortNames,cm);
+  GraphWriter<GraphType> W(O, G, ShortNames, cm);
 
   // Emit the graph.
   W.writeGraph(Title.str());
@@ -349,8 +330,7 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
       assert(AS);
       ++i;
       O << " " << DOT::EscapeString(AS->hasName() ? AS->getName() : "unnamed");
-      if (i != numAllocSites)
-        O << ",";
+      if (i != numAllocSites) O << ",";
     }
     O << "\n";
   }
@@ -362,12 +342,10 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
     if (N->isForwarding()) {
       OS << "FORWARDING";
     } else {
-      if (N->isOffsetCollapsed() || (N->isTypeCollapsed() &&
-                                     seadsa::g_IsTypeAware)) {
-        if (N->isOffsetCollapsed())
-          OS << "OFFSET-";
-        if (N->isTypeCollapsed() && seadsa::g_IsTypeAware)
-          OS << "TYPE-";
+      if (N->isOffsetCollapsed() ||
+          (N->isTypeCollapsed() && seadsa::g_IsTypeAware)) {
+        if (N->isOffsetCollapsed()) OS << "OFFSET-";
+        if (N->isTypeCollapsed() && seadsa::g_IsTypeAware) OS << "TYPE-";
         OS << "COLLAPSED";
       } else {
         // Go through all the types, and just print them.
@@ -376,15 +354,13 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
         OS << "{";
         if (ts.begin() != ts.end()) {
           for (auto ii = ts.begin(), ee = ts.end(); ii != ee; ++ii) {
-            if (!firstType)
-              OS << ",";
+            if (!firstType) OS << ",";
             firstType = false;
             OS << ii->first << ":"; // offset
             if (ii->second.begin() != ii->second.end()) {
               bool first = true;
               for (const Type *t : ii->second) {
-                if (!first)
-                  OS << "|";
+                if (!first) OS << "|";
                 t->print(OS);
                 first = false;
               }
@@ -398,40 +374,24 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
       }
       OS << ":";
       typename seadsa::Node::NodeType node_type = N->getNodeType();
-      if (node_type.array)
-        OS << " Sequence ";
-      if (node_type.alloca)
-        OS << "S";
-      if (node_type.heap)
-        OS << "H";
-      if (node_type.global)
-        OS << "G";
-      if (node_type.unknown)
-        OS << "U";
-      if (node_type.incomplete)
-        OS << "I";
-      if (node_type.modified)
-        OS << "M";
-      if (node_type.read)
-        OS << "R";
-      if (node_type.external)
-        OS << "E";
-      if (node_type.externFunc)
-        OS << "X";
-      if (node_type.externGlobal)
-        OS << "Y";
-      if (node_type.inttoptr)
-        OS << "P";
-      if (node_type.ptrtoint)
-        OS << "2";
-      if (node_type.vastart)
-        OS << "V";
-      if (node_type.dead)
-        OS << "D";
+      if (node_type.array) OS << " Sequence ";
+      if (node_type.alloca) OS << "S";
+      if (node_type.heap) OS << "H";
+      if (node_type.global) OS << "G";
+      if (node_type.unknown) OS << "U";
+      if (node_type.incomplete) OS << "I";
+      if (node_type.modified) OS << "M";
+      if (node_type.read) OS << "R";
+      if (node_type.external) OS << "E";
+      if (node_type.externFunc) OS << "X";
+      if (node_type.externGlobal) OS << "Y";
+      if (node_type.inttoptr) OS << "P";
+      if (node_type.ptrtoint) OS << "2";
+      if (node_type.vastart) OS << "V";
+      if (node_type.dead) OS << "D";
     }
 
-    if (PrintAllocSites)
-      writeAllocSites(*N, OS);
+    if (PrintAllocSites) writeAllocSites(*N, OS);
 
     return OS.str();
   }
@@ -451,8 +411,7 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
     Res.reserve(S.size() + 2);
 
     for (char C : S) {
-      if (C == '"')
-        Res.push_back('\\');
+      if (C == '"') Res.push_back('\\');
       Res.push_back(C);
     }
 
@@ -520,22 +479,21 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
     auto et = Node->links().end();
     unsigned idx = 0;
     for (; it != et; ++it, ++idx) {
-      if (it->first == Offset)
-        return idx;
+      if (it->first == Offset) return idx;
     }
     return -1;
   }
 
-  static void addCustomGraphFeatures(
-      seadsa::Graph *g,
-      seadsa::internals::GraphWriter<seadsa::Graph *> &GW) {
+  static void
+  addCustomGraphFeatures(seadsa::Graph *g,
+                         seadsa::internals::GraphWriter<seadsa::Graph *> &GW) {
 
     typedef seadsa::Node Node;
     typedef seadsa::Field Field;
 
     auto EmitLinkTypeSuffix = [](const seadsa::Cell &C,
                                  seadsa::FieldType Ty =
-                                                   FIELD_TYPE_NOT_IMPLEMENTED) {
+                                     FIELD_TYPE_NOT_IMPLEMENTED) {
       std::string Buff;
       llvm::raw_string_ostream OS(Buff);
 
@@ -649,7 +607,7 @@ static std::string appendOutDir(std::string FileName) {
   return FileName;
 }
 
-static bool writeGraph(Graph *G, std::string Filename, ColorMap * cm = nullptr) {
+static bool writeGraph(Graph *G, std::string Filename, ColorMap *cm = nullptr) {
   std::string FullFilename = appendOutDir(Filename);
   std::error_code EC;
   raw_fd_ostream File(FullFilename, EC, sys::fs::F_Text);
@@ -668,36 +626,37 @@ class DsaPrinterImpl {
   CompleteCallGraph *m_ccg;
   // -- print summary graphs
   bool m_print_sum_graphs;
-  // 
-  
+  //
+
   bool runOnFunction(Function &F) {
     if (m_dsa.hasGraph(F)) {
       Graph *G = &m_dsa.getGraph(F);
       if (G->begin() != G->end()) {
         std::string Filename = F.getName().str() + ".mem.dot";
         writeGraph(G, Filename);
-        if (DsaColorFunctionSimDot || m_print_sum_graphs) { // simulate bu and sas graph and color
+        if (DsaColorFunctionSimDot ||
+            m_print_sum_graphs) { // simulate bu and sas graph and color
           if (m_dsa.hasSummaryGraph(F)) {
             Graph *buG = &m_dsa.getSummaryGraph(F);
             ColorMap colorBuG, colorG;
             colorGraphsFunction(F, *buG, *G, colorBuG, colorG);
             writeGraph(buG, F.getName().str() + ".BU.mem.dot", &colorBuG);
-	    if (DsaColorFunctionSimDot) {
-	      writeGraph(G, F.getName().str() + ".TD.mem.dot", &colorG);
-	    }
+            if (DsaColorFunctionSimDot) {
+              writeGraph(G, F.getName().str() + ".TD.mem.dot", &colorG);
+            }
           }
         }
       }
     }
     return false;
   }
-  
-public :
 
-  DsaPrinterImpl(GlobalAnalysis &dsa, CompleteCallGraph *ccg, bool printSumGraphs)
-    : m_dsa(dsa), m_ccg(ccg), m_print_sum_graphs(printSumGraphs) {}
+public:
+  DsaPrinterImpl(GlobalAnalysis &dsa, CompleteCallGraph *ccg,
+                 bool printSumGraphs)
+      : m_dsa(dsa), m_ccg(ccg), m_print_sum_graphs(printSumGraphs) {}
 
-  bool runOnModule(Module &M)  {
+  bool runOnModule(Module &M) {
     if (m_dsa.kind() == GlobalAnalysisKind::CONTEXT_INSENSITIVE) {
       Function *main = M.getFunction("main");
       if (main && m_dsa.hasGraph(*main)) {
@@ -706,41 +665,36 @@ public :
         writeGraph(G, Filename);
       }
     } else {
-      if(DsaColorCallSiteSimDot && m_ccg){
-	unsigned cs_count = 0;
+      if (DsaColorCallSiteSimDot && m_ccg) {
+        unsigned cs_count = 0;
         llvm::CallGraph &cg = m_ccg->getCompleteCallGraph();
         for (auto it = scc_begin(&cg); !it.isAtEnd(); ++it) {
           auto &scc = *it;
           for (CallGraphNode *cgn : scc) {
             Function *fn = cgn->getFunction();
-            if (!fn || fn->isDeclaration() || fn->empty()) {
-              continue;
-            }
+            if (!fn || fn->isDeclaration() || fn->empty()) { continue; }
             // -- store the simulation maps from the SCC
             for (auto &callRecord : *cgn) {
               llvm::Optional<DsaCallSite> dsaCS =
-		call_graph_utils::getDsaCallSite(callRecord);
-              if (!dsaCS.hasValue()) {
-                continue;
-              }
+                  call_graph_utils::getDsaCallSite(callRecord);
+              if (!dsaCS.hasValue()) { continue; }
               DsaCallSite &cs = dsaCS.getValue();
-              Function * f_caller = fn;
-              const Function * f_callee = cs.getCallee();
+              Function *f_caller = fn;
+              const Function *f_callee = cs.getCallee();
               Graph &callerG = m_dsa.getGraph(*f_caller);
               Graph &calleeG = m_dsa.getSummaryGraph(*f_callee);
               ColorMap color_callee, color_caller;
               colorGraphsCallSite(cs, calleeG, callerG, color_callee,
                                   color_caller);
               std::string FilenameBase =
-                f_caller->getParent()->getModuleIdentifier() + "." +
-                f_caller->getName().str() + "." + f_callee->getName().str() +
-                "." + std::to_string(++cs_count);
+                  f_caller->getParent()->getModuleIdentifier() + "." +
+                  f_caller->getName().str() + "." + f_callee->getName().str() +
+                  "." + std::to_string(++cs_count);
 
               writeGraph(&calleeG, FilenameBase + ".callee.mem.dot",
                          &color_callee);
               writeGraph(&callerG, FilenameBase + ".caller.mem.dot",
                          &color_caller);
-
             }
           }
         }
@@ -753,49 +707,43 @@ public :
   }
 };
 
-DsaPrinter::DsaPrinter(GlobalAnalysis &dsa, CompleteCallGraph *ccg, bool printSumGraphs)
-  : m_impl(std::make_unique<DsaPrinterImpl>(dsa, ccg, printSumGraphs)) {}
+DsaPrinter::DsaPrinter(GlobalAnalysis &dsa, CompleteCallGraph *ccg,
+                       bool printSumGraphs)
+    : m_impl(std::make_unique<DsaPrinterImpl>(dsa, ccg, printSumGraphs)) {}
 
 DsaPrinter::~DsaPrinter() {}
 
-bool DsaPrinter::runOnModule(Module &M) {
-  return m_impl->runOnModule(M);
-}
+bool DsaPrinter::runOnModule(Module &M) { return m_impl->runOnModule(M); }
 
-
-DsaPrinterPass::DsaPrinterPass(): ModulePass(ID) {}
+DsaPrinterPass::DsaPrinterPass() : ModulePass(ID) {}
 
 bool DsaPrinterPass::runOnModule(Module &M) {
   auto &dsa = getAnalysis<seadsa::DsaAnalysis>();
   CompleteCallGraph *ccg = nullptr;
-  if (DsaColorCallSiteSimDot) {
-    ccg = &getAnalysis<CompleteCallGraph>();    
-  }
+  if (DsaColorCallSiteSimDot) { ccg = &getAnalysis<CompleteCallGraph>(); }
   DsaPrinter printer(dsa.getDsaAnalysis(), ccg);
   return printer.runOnModule(M);
 }
 
-void DsaPrinterPass::getAnalysisUsage(AnalysisUsage &AU) const{
+void DsaPrinterPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
   AU.addRequired<DsaAnalysis>();
-  if (DsaColorCallSiteSimDot) {
-    AU.addRequired<CompleteCallGraph>();
-  }
+  if (DsaColorCallSiteSimDot) { AU.addRequired<CompleteCallGraph>(); }
 }
 
-StringRef DsaPrinterPass::getPassName() const{
+StringRef DsaPrinterPass::getPassName() const {
   return "SeaHorn Dsa graph printer";
 }
 
 // Used by Graph::writeGraph().
-void WriteDsaGraph(Graph& G, const std::string &filename) {
+void WriteDsaGraph(Graph &G, const std::string &filename) {
   const bool Res = writeGraph(&G, filename);
   (void)Res;
   assert(Res && "Could not write graph");
 }
 
 // Used by Graph::viewGraph() and Node::viewGraph().
-void ShowDsaGraph(Graph& G) {
+void ShowDsaGraph(Graph &G) {
   static unsigned I = 0;
   const std::string Filename = "temp" + std::to_string(I++) + ".mem.dot";
   WriteDsaGraph(G, Filename);
@@ -811,7 +759,8 @@ struct DsaViewer : public ModulePass {
 
   bool runOnModule(Module &M) override {
     m_dsa = &getAnalysis<seadsa::DsaAnalysis>();
-    if (m_dsa->getDsaAnalysis().kind() == GlobalAnalysisKind::CONTEXT_INSENSITIVE) {
+    if (m_dsa->getDsaAnalysis().kind() ==
+        GlobalAnalysisKind::CONTEXT_INSENSITIVE) {
       Function *main = M.getFunction("main");
       if (main && m_dsa->getDsaAnalysis().hasGraph(*main)) {
         Graph *G = &m_dsa->getDsaAnalysis().getGraph(*main);
@@ -844,9 +793,7 @@ struct DsaViewer : public ModulePass {
     AU.addRequired<DsaAnalysis>();
   }
 
-  StringRef getPassName() const override 
-  { return "SeaDsa graph viewer"; }
-
+  StringRef getPassName() const override { return "SeaDsa graph viewer"; }
 };
 
 char DsaPrinterPass::ID = 0;
@@ -858,8 +805,8 @@ Pass *createDsaViewerPass() { return new seadsa::DsaViewer(); }
 
 } // end namespace seadsa
 
-static llvm::RegisterPass<seadsa::DsaPrinterPass> X("seadsa-printer",
-						    "Print SeaDsa memory graphs");
+static llvm::RegisterPass<seadsa::DsaPrinterPass>
+    X("seadsa-printer", "Print SeaDsa memory graphs");
 
 static llvm::RegisterPass<seadsa::DsaViewer> Y("seadsa-viewer",
-                                                "View SeaDsa memory graphs");
+                                               "View SeaDsa memory graphs");


### PR DESCRIPTION
We have also decoupled the class that prints memory graphs to dot
format from the LLVM pass so that seadsa clients can use the printer
without using the LLVM pass manager.