### PR TITLE
Skip debug functions in the call graph

### DIFF
--- a/lib/seadsa/DsaCompleteCallGraph.cc
+++ b/lib/seadsa/DsaCompleteCallGraph.cc
@@ -7,6 +7,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
@@ -587,6 +588,8 @@ bool CompleteCallGraphAnalysis::runOnModule(Module &M) {
   /// Remove edges in the callgraph: remove original indirect call
   /// from call graph if we now for sure we fully resolved it.
   for (auto &F : M) {
+    if (isDbgInfoIntrinsic(F.getIntrinsicID())) continue;
+
     CallGraphNode *CGNF = (*m_complete_cg)[&F];
     if (!CGNF) continue;
 


### PR DESCRIPTION
`(*m_complete_cg)[&F];` fails for debug intrinsics (e.g., `llvm.dbg.declare`).

Per [this](https://github.com/llvm/llvm-project/blob/release/12.x/llvm/lib/Analysis/CallGraph.cpp#L38) LLVM code, these functions are skipped and so don't appear in the call graph. Sea-dsa must do the same.