### PR TITLE
fix(DsaGlobal): fixed undefined behavior

### DIFF
--- a/include/seadsa/Global.hh
+++ b/include/seadsa/Global.hh
@@ -136,7 +136,7 @@ public:
   bool empty() const;
   size_t size() const;
   void enqueue(const T &e);
-  const T &dequeue();
+  T dequeue();
 
 private:
   struct impl;

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -275,8 +275,8 @@ template <typename T> void WorkList<T>::enqueue(const T &e) {
   auto p = m_pimpl->m_s.insert(e);
   if (p.second) { m_pimpl->m_w.push(e); }
 }
-template <typename T> const T &WorkList<T>::dequeue() {
-  const T &e = m_pimpl->m_w.front();
+template <typename T> T WorkList<T>::dequeue() {
+  T e = m_pimpl->m_w.front();
   m_pimpl->m_w.pop();
   m_pimpl->m_s.erase(e);
   return e;


### PR DESCRIPTION
Popping the front of an std::queue and using the returned reference is undefined behavior (see, for example, https://stackoverflow.com/questions/63599011/getting-reference-of-the-front-element-when-queue-is-popped). Return a copy rather than a reference.

For me, this resulted in a UAF and hence segmentation fault :(