### PR TITLE
fix(RemovePtrToInt): Fix use-after-free

### DIFF
--- a/lib/seadsa/RemovePtrToInt.cc
+++ b/lib/seadsa/RemovePtrToInt.cc
@@ -501,8 +501,10 @@ bool RemovePtrToInt::runOnFunction(Function &F) {
     }
   }
 
-  for (auto *SI : StoresToErase)
+  for (auto *SI : StoresToErase) {
+    MaybeUnusedInsts.erase(SI);
     SI->eraseFromParent();
+  }
 
   SmallVector<Instruction *, 16> TriviallyDeadInstructions(
       llvm::make_filter_range(MaybeUnusedInsts, [](Instruction *I) {


### PR DESCRIPTION
A use-after-free occurs when a store instruction in `StoresToErase` is also in the `MaybeUnusedInsts` set. Remove it from the `MaybeUnusedInsts` set before erasing it.