### PR TITLE
Experimental LLVM 15 Port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,13 @@ option (SEA_DSA_STATIC_EXE "Static executable." OFF)
 
 ## llvm
 if (TOP_LEVEL)
-  find_package (LLVM 14.0 CONFIG)
+  find_package (LLVM 15.0 CONFIG)
   if (NOT LLVM_FOUND)
     ExternalProject_Get_Property (llvm INSTALL_DIR)
     set (LLVM_ROOT ${INSTALL_DIR})
     set (LLVM_DIR ${LLVM_ROOT}/lib/cmake/llvm CACHE PATH
       "Forced location of LLVM cmake config" FORCE)
-    message (WARNING "No llvm found. Install LLVM 14.")
+    message (WARNING "No llvm found. Install LLVM 15.")
     return()
   endif()
 

--- a/include/seadsa/FieldType.hh
+++ b/include/seadsa/FieldType.hh
@@ -89,14 +89,6 @@ public:
     return FieldType(PtrTy);
   }
 
-  FieldType elemOf() const {
-    assert(!isUnknown());
-    assert(isPointer());
-
-    auto *NewTy = m_ty->getPointerElementType();
-    return FieldType(NewTy);
-  }
-
   void dump(llvm::raw_ostream &OS = llvm::errs()) const {
     if (m_NOT_IMPLEMENTED) {
       OS << "TODO<" << m_whereNotImpl << ">";

--- a/lib/seadsa/Cloner.cc
+++ b/lib/seadsa/Cloner.cc
@@ -27,23 +27,11 @@ static bool isConstantNoPtr(const llvm::Value *v) {
   if (v->hasName() && v->getName().startswith(".str."))
     return true;
 
-  if (!v->getType()->isPointerTy())
-    return false;
+  if (!v->getType()->isPointerTy()) return false;
 
-  auto *type = v->getType()->getPointerElementType();
-  if (type->isIntegerTy() || type->isFloatingPointTy())
-    return true;
-
-  // auto *compositeTy = llvm::dyn_cast<llvm::CompositeType>(type);
-  // Shaobo: LLVM 11 removes `CompositeType`, which was a union of ArrayType,
-  // StructType, and VectorType.
-  if (!type->isAggregateType() && !type->isVectorTy())
-    return false;
-
-  return std::all_of(type->subtype_begin(), type->subtype_end(),
-                     [](const llvm::Type *ty) {
-                       return ty->isIntegerTy() || ty->isFloatingPointTy();
-                     });
+  // TODO: Can infer pointer type by checking its uses. For now, not much
+  // can be done and precision will be lost to opaque pointers in LLVM 15.
+  return false;
 }
 
 Node &Cloner::clone(const Node &n, bool forceAddAlloca,

--- a/lib/seadsa/DsaLibFuncInfo.cc
+++ b/lib/seadsa/DsaLibFuncInfo.cc
@@ -356,7 +356,7 @@ void DsaLibFuncInfo::generateSpec(const llvm::Function &F,
     builder.CreateRet(retVal);
   } else if (!retVal && F.getReturnType()->getTypeID()) {
     retVal = builder.CreateAlloca(F.getReturnType(), nullptr);
-    Value *loadedRet = builder.CreateLoad(retVal->getType()->getPointerElementType(), retVal);
+    Value *loadedRet = builder.CreateLoad(F.getReturnType(), retVal);
     builder.CreateRet(loadedRet);
   }
 }

--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -168,8 +168,9 @@ Function *getCalledFunction(CallBase &CB) {
 
 namespace {
 // forward declaration
-std::pair<int64_t, uint64_t>
-computeGepOffset(Type *ptrTy, ArrayRef<Value *> Indicies, const DataLayout &dl);
+std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
+                                              ArrayRef<Value *> Indicies,
+                                              const DataLayout &dl);
 
 /*****************************************************************************/
 /* BlockBuilderBase */
@@ -316,32 +317,37 @@ class GlobalBuilder : public BlockBuilderBase {
     if (isa<ConstantDataSequential>(Init)) { return; }
 
     if (Init->getType()->isPointerTy() && !isa<ConstantPointerNull>(Init)) {
-      if (cast<PointerType>(Init->getType())
-              ->getElementType()
-              ->isFunctionTy()) {
-        seadsa::Node &n = m_graph.mkNode();
-        seadsa::Cell nc(n, 0);
-        seadsa::DsaAllocSite *site = m_graph.mkAllocSite(*Init);
-        assert(site);
-        n.addAllocSite(*site);
+      // FIXME: This creates a node for a global function pointer. Needed by
+      // vtable in C++
+      // Disabled for now since in LLVM 15 there is no way to determine if the pointer is a
+      // function. May be inferenced by checking if the pointer is ever loaded as a function.
 
-        // connect c with nc
-        c.growSize(0, Init->getType());
-        c.addAccessedType(0, Init->getType());
-        c.addLink(seadsa::Field(0, seadsa::FieldType(Init->getType())), nc);
-        return;
-      }
+      // if (cast<PointerType>(Init->getType())
+      //         ->getElementType()
+      //         ->isFunctionTy()) {
+      //   seadsa::Node &n = m_graph.mkNode();
+      //   seadsa::Cell nc(n, 0);
+      //   seadsa::DsaAllocSite *site = m_graph.mkAllocSite(*Init);
+      //   assert(site);
+      //   n.addAllocSite(*site);
 
-      if (m_graph.hasCell(*Init)) {
-        // @g1 =  ...*
-        // @g2 =  ...** @g1
-        seadsa::Cell &nc = m_graph.mkCell(*Init, seadsa::Cell());
-        // connect c with nc
-        c.growSize(0, Init->getType());
-        c.addAccessedType(0, Init->getType());
-        c.addLink(seadsa::Field(0, seadsa::FieldType(Init->getType())), nc);
-        return;
-      }
+      //   // connect c with nc
+      //   c.growSize(0, Init->getType());
+      //   c.addAccessedType(0, Init->getType());
+      //   c.addLink(seadsa::Field(0, seadsa::FieldType(Init->getType())), nc);
+      //   return;
+      // }
+
+      // if (m_graph.hasCell(*Init)) {
+      //   // @g1 =  ...*
+      //   // @g2 =  ...** @g1
+      //   seadsa::Cell &nc = m_graph.mkCell(*Init, seadsa::Cell());
+      //   // connect c with nc
+      //   c.growSize(0, Init->getType());
+      //   c.addAccessedType(0, Init->getType());
+      //   c.addLink(seadsa::Field(0, seadsa::FieldType(Init->getType())), nc);
+      //   return;
+      // }
     }
   }
 
@@ -458,8 +464,7 @@ class IntraBlockBuilder : public InstVisitor<IntraBlockBuilder>,
   void visitIntToPtrInst(IntToPtrInst &I);
   void visitPtrToIntInst(PtrToIntInst &I);
   void visitBitCastInst(BitCastInst &I);
-  void visitCmpInst(CmpInst &I) { /* do nothing */
-  }
+  void visitCmpInst(CmpInst &I) { /* do nothing */ }
   void visitInsertValueInst(InsertValueInst &I);
   void visitExtractValueInst(ExtractValueInst &I);
   void visitShuffleVectorInst(ShuffleVectorInst &I);
@@ -478,7 +483,6 @@ class IntraBlockBuilder : public InstVisitor<IntraBlockBuilder>,
 
   void visitAllocWrapperCall(CallBase &I);
   void visitAllocationFnCall(CallBase &I);
-
 
   SeadsaFn getSeaDsaFn(const Function *fn) {
     if (!fn) return SeadsaFn::UNKNOWN;
@@ -786,10 +790,6 @@ void IntraBlockBuilder::visitAtomicRMWInst(AtomicRMWInst &I) {
   }
 }
 
-static bool isBytePtrTy(const Type *ty) {
-  return ty->isPointerTy() && ty->getPointerElementType()->isIntegerTy(8);
-}
-
 void IntraBlockBuilder::visitStoreInst(StoreInst &SI) {
   using namespace seadsa;
 
@@ -837,14 +837,10 @@ void IntraBlockBuilder::visitStoreInst(StoreInst &SI) {
   Cell dest(val.getNode(), val.getRawOffset());
 
   // -- guess best type for the store. Use the type of the value being
-  // -- stored, unless it is i8*, in which case check if the store location
-  // -- has a better type
+  // -- stored
+  // Since LLVM 15, a loss of precision is incurred compared to past version for when omnichar pointers are being stored
   Type *ty = ValOp->getType();
-  if (isBytePtrTy(ty)) {
-    Type *opTy = SI.getPointerOperand()->stripPointerCasts()->getType();
-    if (opTy->isPointerTy() && opTy->getPointerElementType()->isPointerTy())
-      ty = opTy->getPointerElementType();
-  }
+
   base.addLink(Field(0, FieldType(ty)), dest);
 }
 
@@ -877,11 +873,11 @@ template <typename T> T gcd(T a, T b) {
    The first element of the pair is the fixed offset. The second is
    a gcd of the variable offset.
  */
-std::pair<int64_t, uint64_t> computeGepOffset(Type *ptrTy,
+std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
                                               ArrayRef<Value *> Indicies,
                                               const DataLayout &dl) {
-  Type *Ty = ptrTy;
-  assert(Ty->isPointerTy());
+
+  Type *Ty = srcElementTy;
 
   // numeric offset
   int64_t noffset = 0;
@@ -889,9 +885,8 @@ std::pair<int64_t, uint64_t> computeGepOffset(Type *ptrTy,
   // divisor
   uint64_t divisor = 0;
 
-  Type *srcElemTy = cast<PointerType>(ptrTy)->getElementType();
   generic_gep_type_iterator<Value *const *> TI =
-      gep_type_begin(srcElemTy, Indicies);
+      gep_type_begin(srcElementTy, Indicies);
 
   for (unsigned CurIDX = 0, EndIDX = Indicies.size(); CurIDX != EndIDX;
        ++CurIDX, ++TI) {
@@ -900,9 +895,8 @@ std::pair<int64_t, uint64_t> computeGepOffset(Type *ptrTy,
       noffset += dl.getStructLayout(STy)->getElementOffset(fieldNo);
       Ty = STy->getElementType(fieldNo);
     } else {
-      if (PointerType *ptrTy = dyn_cast<PointerType>(Ty))
-        Ty = ptrTy->getElementType();
-      else if (Ty->isArrayTy())
+      // We do nothing to pointer type now
+      if (Ty->isArrayTy())
         Ty = Ty->getArrayElementType();
       else if (auto vt = dyn_cast<VectorType>(Ty))
         Ty = vt->getElementType();
@@ -939,13 +933,11 @@ uint64_t computeIndexedOffset(Type *ty, ArrayRef<unsigned> indecies,
       offset += layout->getElementOffset(idx);
       ty = sty->getElementType(idx);
     } else {
-      if (PointerType *ptrTy = dyn_cast<PointerType>(ty))
-        ty = ptrTy->getElementType();
-      else if (ty->isArrayTy())
+      if (ty->isArrayTy())
         ty = ty->getArrayElementType();
       else if (auto vt = dyn_cast<VectorType>(ty))
         ty = vt->getElementType();
-      assert(ty && "Type is neither PointerType nor SequentialType");
+      assert(ty && "Type being indexed is not a SequentialType");
       offset += idx * dl.getTypeAllocSize(ty);
     }
   }
@@ -1006,7 +998,21 @@ void BlockBuilderBase::visitGep(const Value &gep, const Value &ptr,
     return;
   }
 
-  auto off = computeGepOffset(ptr.getType(), indicies, m_dl);
+  Type *srcElementType;
+
+  // We require a cast to GEPOperator first, since we can only acquire the
+  // source element type through GEPOperator.
+  if (auto *g = dyn_cast<GEPOperator>(&gep)) {
+    srcElementType = g->getSourceElementType();
+  } else {
+    errs() << "Attempted to cast following value into a GEP instruction: ";
+    gep.print(llvm::errs());
+    errs() << "\n";
+    assert(false && "Not a GEP instruction");
+    return;
+  }
+
+  auto off = computeGepOffset(srcElementType, indicies, m_dl);
   if (off.first < 0) {
     if (base.getOffset() + off.first >= 0) {
       m_graph.mkCell(gep,
@@ -1463,7 +1469,6 @@ void IntraBlockBuilder::visitCallBase(CallBase &I) {
   // a function that does not return a pointer is a noop
   if (!I.getType()->isPointerTy()) return;
 
-
   // -- something unexpected. Keep an assert so that we know that something
   // -- unexpected happened.
 
@@ -1510,50 +1515,55 @@ bool hasNoPointerTy(const llvm::Type *t) {
 }
 
 bool transfersNoPointers(MemTransferInst &MI, const DataLayout &DL) {
-  Value *srcPtr = MI.getSource();
-  auto *srcTy = srcPtr->getType()->getPointerElementType();
+  // FIXME: LLVM 15, Kevin: Since we can no longer access pointee types, it is
+  // now
+  // impossible to determine whether the pointee's struct type contains
+  // pointers. This whole function is effectively hamstrung as it now only
+  // returns false.
 
   ConstantInt *rawLength = dyn_cast<ConstantInt>(MI.getLength());
-  if (!rawLength) return false;
+  if (!rawLength)
+    return false; // Analysis is not possible if length is not constant
 
   const uint64_t length = rawLength->getZExtValue();
   LOG("dsa", errs() << "MemTransfer length:\t" << length << "\n");
 
-  // opaque structs may transfer pointers
-  if (!srcTy->isSized()) return false;
+  // // opaque structs may transfer pointers
+  // if (!srcTy->isSized()) return false;
 
-  // TODO: Go up to the GEP chain to find nearest fitting type to transfer.
-  // This can occur when someone tries to transfer int the middle of a struct.
-  if (length * 8 > DL.getTypeSizeInBits(srcTy)) {
-    LOG("dsa-warn", errs() << "WARNING: MemTransfer past object size!\n"
-                           << "\tTransfer:  ");
-    LOG("dsa", MI.print(errs()));
-    LOG("dsa-warn", errs() << "\n\tLength:  " << length << "\n\tType size:  "
-                           << (DL.getTypeSizeInBits(srcTy) / 8) << "\n");
-    return false;
-  }
+  // // TODO: Go up to the GEP chain to find nearest fitting type to transfer.
+  // // This can occur when someone tries to transfer int the middle of a struct.
+  // if (length * 8 > DL.getTypeSizeInBits(srcTy)) {
+  //   LOG("dsa-warn", errs() << "WARNING: MemTransfer past object size!\n"
+  //                          << "\tTransfer:  ");
+  //   LOG("dsa", MI.print(errs()));
+  //   LOG("dsa-warn", errs() << "\n\tLength:  " << length << "\n\tType size:  "
+  //                          << (DL.getTypeSizeInBits(srcTy) / 8) << "\n");
+  //   return false;
+  // }
 
-  static SmallDenseMap<std::pair<Type *, unsigned>, bool, 16>
-      knownNoPointersInStructs;
+  // static SmallDenseMap<std::pair<Type *, unsigned>, bool, 16>
+  //     knownNoPointersInStructs;
 
-  if (knownNoPointersInStructs.count({srcTy, length}) != 0)
-    return knownNoPointersInStructs[{srcTy, length}];
+  // if (knownNoPointersInStructs.count({srcTy, length}) != 0)
+  //   return knownNoPointersInStructs[{srcTy, length}];
 
-  for (auto &subTy : seadsa::AggregateIterator::range(srcTy, &DL)) {
-    if (subTy.Offset >= length) break;
+  // for (auto &subTy : seadsa::AggregateIterator::range(srcTy, &DL)) {
+  //   if (subTy.Offset >= length) break;
 
-    if (subTy.Ty->isPointerTy()) {
-      LOG("dsa", errs() << "Found ptr member "; subTy.Ty->print(errs());
-          errs() << "\n\tin "; srcTy->print(errs());
-          errs() << "\n\tMemTransfer transfers pointers!\n");
+  //   if (subTy.Ty->isPointerTy()) {
+  //     LOG("dsa", errs() << "Found ptr member "; subTy.Ty->print(errs());
+  //         errs() << "\n\tin "; srcTy->print(errs());
+  //         errs() << "\n\tMemTransfer transfers pointers!\n");
 
-      knownNoPointersInStructs[{srcTy, length}] = false;
-      return false;
-    }
-  }
+  //     knownNoPointersInStructs[{srcTy, length}] = false;
+  //     return false;
+  //   }
+  // }
 
-  knownNoPointersInStructs[{srcTy, length}] = true;
-  return true;
+  // knownNoPointersInStructs[{srcTy, length}] = true;
+  // return true;
+  return false;
 }
 
 void IntraBlockBuilder::visitMemTransferInst(MemTransferInst &I) {
@@ -1589,9 +1599,9 @@ void IntraBlockBuilder::visitMemTransferInst(MemTransferInst &I) {
   seadsa::Cell destCell = m_graph.mkCell(*I.getDest(), seadsa::Cell());
 
   if (TrustTypes &&
-      ((sourceCell.getNode()->links().size() == 0 &&
-        hasNoPointerTy(I.getSource()->getType()->getPointerElementType())) ||
-       transfersNoPointers(I, m_dl))) {
+      // FIXME: LLVM 15, Kevin: The removal of the pointer type means we can no longer avoid unification upon a memory
+      // operation by looking at its type.
+      (transfersNoPointers(I, m_dl))) {
     /* do nothing */
     // no pointers are copied from source to dest, so there is no
     // need to unify them

--- a/lib/seadsa/FieldType.cc
+++ b/lib/seadsa/FieldType.cc
@@ -38,19 +38,16 @@ llvm::Type *GetInnermostTypeImpl(llvm::Type *const Ty, SeenTypes &seen) {
   while (!seen.count(currentTy)) {
     seen.insert(currentTy);
 
-    if (currentTy->isPointerTy()) {
-      auto *ElemTy = currentTy->getPointerElementType();
-      currentTy = GetInnermostTypeImpl(ElemTy, seen)
-                      ->getPointerTo(currentTy->getPointerAddressSpace());
-      break;
-    }
+    // FIXME: We're at a dead-end when we encounter a pointer type.
+    if (currentTy->isPointerTy()) break;
 
     auto It = AggregateIterator::mkBegin(currentTy, /* DL = */ nullptr);
     auto *FirstTy = It->Ty;
     if (!FirstTy) break;
 
-    if (FirstTy->isPointerTy() && FirstTy->getPointerElementType() == currentTy)
-      break;
+    // FIXME: We cannot check this
+    // if (FirstTy->isPointerTy() && FirstTy->getPointerElementType() == currentTy)
+    //   break;
 
     if (FirstTy == currentTy) break;
 
@@ -64,6 +61,7 @@ llvm::Type *GetInnermostTypeImpl(llvm::Type *const Ty, SeenTypes &seen) {
 
 /// This is intended to be used within a single llvm::Context. When there's more
 /// than one context, the caching might misbehave.
+/// LLVM 15: the lack of a pointee type means that pointers are also primitive types, which may be returned.
 llvm::Type *GetFirstPrimitiveTy(llvm::Type *const Ty) {
   assert(Ty);
 
@@ -85,8 +83,9 @@ static bool IsOmnipotentChar(llvm::Type *const Ty) {
 }
 
 static bool IsOmnipotentPtr(llvm::Type *const Ty) {
-  auto res = Ty->isPointerTy() && IsOmnipotentChar(Ty->getPointerElementType());
-  return res;
+  // LLVM 15, Kevin: Opaque pointer prevents us from being able to determine if a pointer
+  // is omnipotent. Conservatively return false.
+  return false;
 }
 
 FieldType::FieldType(llvm::Type *Ty) {

--- a/lib/seadsa/RemovePtrToInt.cc
+++ b/lib/seadsa/RemovePtrToInt.cc
@@ -143,15 +143,14 @@ static bool visitStoreInst(StoreInst *SI, Function &F, const DataLayout &DL,
 
     Rewrites the following use of ptrtoint
 
-    %20 = ptrtoint %struct.Entry* %m to i32
-    %22 = getelementptr inbounds %struct.Entry, %struct.Entry* %G, i32 0, i32 1
-    %23 = bitcast %struct.Entry** %22 to i32*
-    store i32 %20, i32* %23
+    %20 = ptrtoint ptr %m to i32
+    %22 = getelementptr inbounds %struct.Entry, ptr %G, i32 0, i32 1
+    store i32 %20, ptr %22
 
     Into
 
-    %22 = getelementptr inbounds %struct.Entry, %struct.Entry* %G, i32 0, i32 1
-    store %struct.Entry* %m, %struct.Entry** %22
+    %22 = getelementptr inbounds %struct.Entry, ptr %G, i32 0, i32 1
+    store ptr %m, ptr %22
 
    */
   // -- clang-format on
@@ -160,42 +159,19 @@ static bool visitStoreInst(StoreInst *SI, Function &F, const DataLayout &DL,
   auto *P2I = dyn_cast<PtrToIntInst>(SI->getValueOperand());
   if (!P2I) return false;
 
-  auto *BC = dyn_cast<BitCastInst>(SI->getPointerOperand());
-  if (!BC) return false;
+  auto *GEP = dyn_cast<GetElementPtrInst>(SI->getPointerOperand());
+  if (!GEP) return false;
 
   auto *PtrVal = P2I->getPointerOperand();
   auto *PtrIntTy = DL.getIntPtrType(PtrVal->getType());
-
   if (PtrIntTy != P2I->getType()) return false;
 
-  auto *BCTy = BC->getType();
-  if (!BCTy->isPointerTy() || BCTy->getPointerElementType() != PtrIntTy)
-    return false;
-
-  auto *BCVal = BC->getOperand(0);
-  auto *NewStoreDestTy = BCVal->getType();
-  auto *NewStoreValTy = NewStoreDestTy->getPointerElementType();
-
   IRBuilder<> IRB(SI);
-  if (!NewStoreValTy->isPointerTy()) {
-    // -- if the store value type is not a pointer, but what is being stored is
-    // i8*
-    // -- then store through i8** pointer instead
-    if (PtrVal->getType()->isPointerTy() &&
-        PtrVal->getType()->getPointerElementType()->isIntegerTy(8)) {
-      NewStoreValTy = IRB.getInt8PtrTy();
-      BCVal = IRB.CreateBitCast(BCVal, NewStoreValTy->getPointerTo());
-    } else {
-      return false;
-    }
-  }
 
   DOG(llvm::errs() << "RP2I: cleaning up: " << *SI << "\n";);
-  auto *NewBC = PtrVal->getType() != NewStoreValTy
-                    ? IRB.CreateBitCast(PtrVal, NewStoreValTy)
-                    : PtrVal;
-  auto *res = IRB.CreateStore(NewBC, BCVal);
 
+  // Create a new StoreInst with the same metadata as SI
+  auto *res = IRB.CreateStore(PtrVal, GEP);
   res->setVolatile(SI->isVolatile());
   res->setAlignment(SI->getAlign());
   res->setOrdering(SI->getOrdering());
@@ -205,7 +181,6 @@ static bool visitStoreInst(StoreInst *SI, Function &F, const DataLayout &DL,
   // Collect instructions to erase. Deffer that not to invalidate iterators.
   StoresToErase.insert(SI);
   MaybeUnusedInsts.insert(P2I);
-  MaybeUnusedInsts.insert(BC);
 
   return true;
 }
@@ -213,16 +188,15 @@ static bool visitStoreInst(StoreInst *SI, Function &F, const DataLayout &DL,
 /** Promotes integer expression to pointers to eliminate inttoptr instructions
  */
 class PointerPromoter : public InstVisitor<PointerPromoter, Value *> {
-  Type *m_ty;
   SmallPtrSetImpl<Instruction *> &m_toRemove;
-  DenseMap<Value*, Value*> &m_toReplace;
+  DenseMap<Value *, Value *> &m_toReplace;
   // -- to break cycles in PHINodes
   SmallPtrSet<Instruction *, 16> m_visited;
 
 public:
   PointerPromoter(SmallPtrSetImpl<Instruction *> &toRemove,
                   DenseMap<Value *, Value *> &toReplace)
-    : m_ty(nullptr), m_toRemove(toRemove), m_toReplace(toReplace) {}
+      : m_toRemove(toRemove), m_toReplace(toReplace) {}
 
   Value *visitInstruction(Instruction &I) { return nullptr; }
 
@@ -231,9 +205,7 @@ public:
     m_toRemove.insert(&I);
 
     auto *op = I.getOperand(0);
-    if (op->getType() == m_ty) return op;
-    IRBuilder<> IRB(&I);
-    return IRB.CreateBitCast(op, m_ty);
+    return op;
   }
 
   Value *visitPHINode(PHINode &I) {
@@ -254,7 +226,7 @@ public:
     }
 
     IRBuilder<> IRB(&I);
-    auto *newPhi = IRB.CreatePHI(m_ty, I.getNumIncomingValues());
+    auto *newPhi = IRB.CreatePHI(IRB.getPtrTy(), I.getNumIncomingValues());
 
     for (unsigned i = 0, e = I.getNumIncomingValues(); i < e; ++i) {
       newPhi->addIncoming(vals[i], I.getIncomingBlock(i));
@@ -264,7 +236,6 @@ public:
   }
 
   Value *visitAdd(BinaryOperator &I) {
-    // errs() << "visitAdd: " << I << "\n";
     auto *op0 = dyn_cast<Instruction>(I.getOperand(0));
     if (!op0) return nullptr;
 
@@ -276,9 +247,8 @@ public:
     IRBuilder<> IRB(&I);
 
     ptr = IRB.CreateBitCast(ptr, IRB.getInt8PtrTy());
-    auto *gep = IRB.CreateGEP(ptr->getType()->getScalarType()->getPointerElementType(),
-                              ptr, I.getOperand(1));
-    return IRB.CreateBitCast(gep, m_ty);
+    auto *gep = IRB.CreateGEP(IRB.getInt8Ty(), ptr, I.getOperand(1));
+    return gep;
   }
 
   Value *visitSub(BinaryOperator &I) {
@@ -287,34 +257,30 @@ public:
 
       auto *op0 = dyn_cast<Instruction>(I.getOperand(0));
       if (!op0) return nullptr;
-      
+
       auto *ptr = this->visit(op0);
       if (!ptr) return nullptr;
-      
+
       m_toRemove.insert(&I);
 
       if (CI->isZero()) { return ptr; }
-      
+
       IRBuilder<> IRB(&I);
-      ptr = IRB.CreateBitCast(ptr, IRB.getInt8PtrTy());
-      const APInt &opV = CI->getValue(); 
-      auto *gep =
-        IRB.CreateGEP(ptr->getType()->getScalarType()->getPointerElementType(),
-                      ptr, ConstantInt::get(CI->getType(), opV * -1));
-      return IRB.CreateBitCast(gep, m_ty);
+      const APInt &opV = CI->getValue();
+      auto *gep = IRB.CreateGEP(IRB.getInt8Ty(), ptr,
+                                ConstantInt::get(CI->getType(), opV * -1));
+      return gep;
     } else {
       // TODO: a non-constant operand
-    return nullptr;
-  }
+      return nullptr;
+    }
   }
 
   Value *visitLoad(LoadInst &I) {
-    assert(m_ty);
     // errs() << "visitLoad: " << I << "\n";
     auto *ptr = I.getPointerOperand();
     IRBuilder<> IRB(&I);
-    ptr = IRB.CreateBitCast(ptr, m_ty->getPointerTo());
-    auto *res = IRB.CreateLoad(ptr->getType()->getPointerElementType(), ptr);
+    auto *res = IRB.CreateLoad(IRB.getPtrTy(), ptr);
     res->setVolatile(I.isVolatile());
     res->setAlignment(I.getAlign());
     res->setOrdering(I.getOrdering());
@@ -329,7 +295,6 @@ public:
         if (SI->getValueOperand() != &I) { continue; }
         IRB.SetInsertPoint(SI);
         auto *ptr = SI->getPointerOperand();
-        ptr = IRB.CreateBitCast(ptr, m_ty->getPointerTo());
         auto newStore = IRB.CreateStore(res, ptr);
         newStore->setVolatile(SI->isVolatile());
         newStore->setAlignment(SI->getAlign());
@@ -340,7 +305,7 @@ public:
         m_toRemove.insert(SI);
       } else if (isa<IntToPtrInst>(u)) {
         /* skip  */;
-      } else  {
+      } else {
         // -- if there is an interesting user, schedule it to be replaced
         if (!p2i) {
           IRB.SetInsertPoint(&I);
@@ -356,9 +321,6 @@ public:
   Value *visitIntToPtrInst(IntToPtrInst &I) {
     // errs() << "Visiting: " << I << "\n";
 
-    assert(!m_ty);
-    m_ty = I.getType();
-
     auto *op = dyn_cast<Instruction>(I.getOperand(0));
     Value *ret = nullptr;
     if (op) ret = this->visit(*op);
@@ -367,17 +329,15 @@ public:
       I.replaceAllUsesWith(ret);
       m_toRemove.insert(&I);
     }
-
-    m_ty = nullptr;
     return ret;
   }
 };
 
 static bool visitIntToPtrInst(IntToPtrInst *I2P, Function &F,
                               const DataLayout &DL, DominatorTree &DT,
-                  SmallDenseMap<PHINode *, PHINode *> &NewPhis,
-                  SmallPtrSetImpl<Instruction *> &MaybeUnusedInsts,
-                  DenseMap<Value*, Value*> &RenameMap) {
+                              SmallDenseMap<PHINode *, PHINode *> &NewPhis,
+                              SmallPtrSetImpl<Instruction *> &MaybeUnusedInsts,
+                              DenseMap<Value *, Value *> &RenameMap) {
   assert(I2P);
 
   auto *IntVal = I2P->getOperand(0);
@@ -482,7 +442,7 @@ bool RemovePtrToInt::runOnFunction(Function &F) {
   auto &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
   SmallPtrSet<StoreInst *, 8> StoresToErase;
   SmallPtrSet<Instruction *, 16> MaybeUnusedInsts;
-  DenseMap<Value*, Value*> RenameMap;
+  DenseMap<Value *, Value *> RenameMap;
   SmallDenseMap<PHINode *, PHINode *> NewPhis;
 
   for (auto &BB : F) {
@@ -513,7 +473,7 @@ bool RemovePtrToInt::runOnFunction(Function &F) {
       llvm::make_filter_range(MaybeUnusedInsts, [](Instruction *I) {
         return isInstructionTriviallyDead(I);
       }));
-  
+
   // TODO: RecursivelyDeleteTriviallyDeadInstructions takes a vector of
   // WeakTrackingVH since LLVM 11, which implies that `MaybeUnusedInsts` should
   // be a vector of WeakTrackingVH as well. See comment:
@@ -522,9 +482,9 @@ bool RemovePtrToInt::runOnFunction(Function &F) {
   // removed before this call. So it should be safe to keep its original type
   // and map it to WeakTrackingVH as the following code does.
   SmallVector<WeakTrackingVH, 16> TriviallyDeadHandles;
-  for (auto i : TriviallyDeadInstructions)  
-      TriviallyDeadHandles.emplace_back(WeakTrackingVH(i));
-  
+  for (auto i : TriviallyDeadInstructions)
+    TriviallyDeadHandles.emplace_back(WeakTrackingVH(i));
+
   RecursivelyDeleteTriviallyDeadInstructions(TriviallyDeadHandles);
   for (auto kv : RenameMap) {
     kv.first->replaceAllUsesWith(kv.second);

--- a/lib/seadsa/ShadowMem.cc
+++ b/lib/seadsa/ShadowMem.cc
@@ -100,7 +100,7 @@ Value *getUniqueScalar(LLVMContext &ctx, IRBuilder<> &B, const dsa::Cell &c) {
     // -- able to extend this to single-cell local pointers, but these
     // -- are probably not very common.
     if (auto *gv = dyn_cast_or_null<GlobalVariable>(v))
-      if (gv->getType()->getElementType()->isSingleValueType())
+      if (gv->getValueType()->isSingleValueType())
         return B.CreateBitCast(v, Type::getInt8PtrTy(ctx));
   }
   return ConstantPointerNull::get(Type::getInt8PtrTy(ctx));
@@ -496,7 +496,7 @@ class ShadowMemImpl : public InstVisitor<ShadowMemImpl> {
 
     auto *ci = mkShadowCall(B, c, m_memStoreFn,
                             {m_B->getInt32(getFieldId(c)),
-                             m_B->CreateLoad(v->getType()->getPointerElementType(), v),
+                             m_B->CreateLoad(m_Int32Ty, v),
                              getUniqueScalar(*m_llvmCtx, B, c)},
                             "sm");
     markDefCall(ci, bytes);


### PR DESCRIPTION
# Motivation for this PR

I have made this work-in-progress port to LLVM 15 available for use in research. Through initial testing against verify-c-common benchmark, precision loss appears to be outweighed by the need to unblock ongoing research efforts for some people.

Specifically, there are loss of precision due to pointee type information no longer provided by the LLVM IR. While a few functions in this PR was able to be refactored to maintain functionality (although no testing is done yet to confirm), most changes involved commenting out a signification portion of the code and resorting to return a safer and imprecise answer.

Work is ongoing to improve this port. See https://github.com/seahorn/sea-dsa/pull/162 for details.