### PR TITLE
fix(graph): update type awareness assertion to include omni type

### DIFF
--- a/include/seadsa/Graph.hh
+++ b/include/seadsa/Graph.hh
@@ -735,7 +735,7 @@ public:
   void growSize(unsigned v);
 
   bool hasLink(Field f) const {
-    assert(g_IsTypeAware || f.getType().isUnknown());
+    assert(g_IsTypeAware || f.getType().isUnknown() || f.getType().isOmniType());
     return m_links.count(Offset::getAdjustedField(*this, f));
   }
 

--- a/lib/seadsa/Graph.cc
+++ b/lib/seadsa/Graph.cc
@@ -389,7 +389,7 @@ Cell &Node::getLink_(const Field &_f) {
 
 const Cell &Node::getLink(Field _f) const {
   assert(!isForwarding());
-  assert(g_IsTypeAware || _f.getType().isUnknown());
+  assert(g_IsTypeAware || f.getType().isUnknown() || f.getType().isOmniType());
   Field f = Offset::getAdjustedField(*this, _f);
 
   if (m_links.count(f)) return *m_links.at(f);


### PR DESCRIPTION
This fix is done with regards to https://github.com/seahorn/sea-dsa/issues/168. The assertions being changed did not account for omni types when not in type awareness mode.