### PR TITLE
ci: run tests on dev14 and main PRs/pushes

### DIFF
--- a/.github/workflows/test-seadsa-docker.yml
+++ b/.github/workflows/test-seadsa-docker.yml
@@ -2,13 +2,13 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Run CI on pushes to and pull requests targeting the LLVM-14 branches.
+# (dev15 is LLVM-15; add it here once main moves to a newer LLVM.)
 on:
-  # Triggers the workflow on push or pull request events but only for the dev14 branch
   push:
-    branches: dev14
+    branches: [dev14, main]
   pull_request:
-    branches: dev14
+    branches: [dev14, main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -19,10 +19,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks out the triggering commit (push) or PR merge ref (pull_request)
       - name: Check out repo
-        uses: actions/checkout@v2
-        with:
-          ref: dev14 # only checkout dev14
+        uses: actions/checkout@v4
+      # The Dockerfile builds seadsa and runs the test targets (test-sea-dsa
+      # for lit tests and sea-dsa-units for unit tests), so a failing test
+      # fails the build.
       - name: Build seadsa and run tests
         run: docker build -t seahorn/sea-dsa-builder:jammy-llvm14 -f docker/sea-dsa-builder.Dockerfile .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+.vscode/
+__pycache__


### PR DESCRIPTION
## What

Fix the CI workflow so it actually runs on the work we do.

- Trigger `push` and `pull_request` on both LLVM-14 branches — `dev14` **and** `main` (was `dev14`-only, so PRs into `main` never ran CI).
- Remove the hardcoded `ref: dev14` in checkout, so the workflow tests the triggering commit / PR merge instead of always building `dev14`.
- Bump `actions/checkout` v2 → v4.
- Start tracking `.gitignore` (`build/`, `.vscode/`, `__pycache__`).

The `docker/sea-dsa-builder.Dockerfile` already builds seadsa and runs the test targets `test-sea-dsa` (lit) and `sea-dsa-units` (unit tests), so a failing test fails the build — no test-wiring change needed.

## Notes / how this gets validated

- This PR will **not** show its own CI run: for `pull_request`, GitHub uses the *base* branch's workflow, and `main` still has the old (dev14-only) workflow until this merges. After merge, pushes and PRs to `main` will run CI.
- To validate before merge, either run `docker build -f docker/sea-dsa-builder.Dockerfile .` locally, or temporarily add this branch to the `push:` trigger and watch the Action.
- `dev14` needs the same workflow for PRs *into* `dev14` to trigger — follow-up to sync `dev14` with `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
