### PR TITLE
feat(newpm): add ShadowMemNewPmPass and AllocSiteInfoAnalysis

### DIFF
--- a/include/seadsa/AllocSiteInfo.hh
+++ b/include/seadsa/AllocSiteInfo.hh
@@ -3,6 +3,7 @@
    information is exposed metadata attached to allocation sites.
  */
 #pragma once
+#include "seadsa/TargetLibraryInfoGetter.hh"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Pass.h"
 
@@ -43,6 +44,9 @@ public:
   AllocSiteInfo()
       : ModulePass(ID), m_tli(nullptr), m_dl(nullptr), m_awi(nullptr) {}
   bool runOnModule(llvm::Module &) override;
+  /// shared with the new-PM analysis: awi must already be initialized
+  bool runImpl(llvm::Module &M, TargetLibraryInfoGetter getTLI,
+               AllocWrapInfo &awi);
   llvm::StringRef getPassName() const override {
     return "Allocation Site Identification pass";
   }

--- a/include/seadsa/SeaDsaAnalysis.hh
+++ b/include/seadsa/SeaDsaAnalysis.hh
@@ -16,6 +16,7 @@
 /// TLI comes from a TargetLibraryInfoGetter sourced from the new-PM
 /// TargetLibraryAnalysis (via the FunctionAnalysisManager proxy) -- no legacy
 /// TargetLibraryInfoWrapperPass is constructed here.
+#include "seadsa/AllocSiteInfo.hh"
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/PassManager.h"
@@ -82,6 +83,31 @@ public:
 /// Cached DsaInfo (sea-dsa's points-to summary). Depends on
 /// AllocWrapInfoAnalysis + DsaLibFuncInfoAnalysis (fetched from the MAM) and
 /// owns the global analysis it is built on.
+/// Runs AllocSiteInfo (marks alloc sites; a transform side effect) and owns
+/// the resulting info object.
+class AllocSiteInfoAnalysis
+    : public llvm::AnalysisInfoMixin<AllocSiteInfoAnalysis> {
+  friend llvm::AnalysisInfoMixin<AllocSiteInfoAnalysis>;
+  static llvm::AnalysisKey Key;
+
+public:
+  class Result {
+    std::unique_ptr<AllocSiteInfo> m_asi;
+
+  public:
+    Result(std::unique_ptr<AllocSiteInfo> asi) : m_asi(std::move(asi)) {}
+    AllocSiteInfo &getAllocSiteInfo() { return *m_asi; }
+    bool invalidate(llvm::Module &, const llvm::PreservedAnalyses &PA,
+                    llvm::ModuleAnalysisManager::Invalidator &) {
+      auto PAC = PA.getChecker<AllocSiteInfoAnalysis>();
+      return !(PAC.preserved() ||
+               PAC.preservedSet<llvm::AllAnalysesOn<llvm::Module>>());
+    }
+  };
+
+  Result run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM);
+};
+
 class DsaInfoAnalysis : public llvm::AnalysisInfoMixin<DsaInfoAnalysis> {
   friend llvm::AnalysisInfoMixin<DsaInfoAnalysis>;
   static llvm::AnalysisKey Key;
@@ -100,6 +126,7 @@ public:
         : m_cg(std::move(cg)), m_setFactory(std::move(sf)), m_ga(std::move(ga)),
           m_info(std::move(info)) {}
     DsaInfo &getDsaInfo() { return *m_info; }
+    GlobalAnalysis &getGlobalAnalysis() { return *m_ga; }
     bool invalidate(llvm::Module &, const llvm::PreservedAnalyses &PA,
                     llvm::ModuleAnalysisManager::Invalidator &) {
       auto PAC = PA.getChecker<DsaInfoAnalysis>();

--- a/include/seadsa/ShadowMem.hh
+++ b/include/seadsa/ShadowMem.hh
@@ -20,9 +20,17 @@ class TargetLibraryInfoWrapperPass;
 class DataLayout;
 class CallGraph;
 class CallInst;
+class DominatorTree;
+class AssumptionCache;
 } // namespace llvm
 
+#include <functional>
+
 namespace seadsa {
+
+using DomTreeGetter = std::function<llvm::DominatorTree &(llvm::Function &)>;
+using AssumptionCacheGetter =
+    std::function<llvm::AssumptionCache &(llvm::Function &)>;
 class ShadowMemImpl;
 class GlobalAnalysis;
 class AllocSiteInfo;
@@ -56,6 +64,12 @@ public:
             bool splitDsaNodes = false, bool computeReadMod = false,
             bool memOptimizer = true, bool useTBAA = true,
             bool useSNAAA = true);
+  /// new-PM construction: analyses provided as getters
+  ShadowMem(GlobalAnalysis &dsa, TargetLibraryInfoGetter getTLI,
+            llvm::CallGraph *cg, DomTreeGetter getDT,
+            AssumptionCacheGetter getAC, bool splitDsaNodes = false,
+            bool computeReadMod = false, bool memOptimizer = true,
+            bool useTBAA = true, bool useSNAAA = true);
 
   ~ShadowMem();
 
@@ -112,6 +126,21 @@ public:
 };
 
 llvm::Pass *createStripShadowMemPass();
+
+/// New-PM twin of ShadowMemPass: instruments the module with shadow.mem
+/// calls, taking sea-dsa's GlobalAnalysis from DsaInfoAnalysis and the
+/// per-function analyses from the FAM. Runs AllocSiteInfoAnalysis for its
+/// alloc-marking side effect first. Pass a sink to keep the ShadowMem
+/// object alive for consumers.
+class ShadowMemNewPmPass : public llvm::PassInfoMixin<ShadowMemNewPmPass> {
+  std::unique_ptr<ShadowMem> *m_keep;
+
+public:
+  ShadowMemNewPmPass(std::unique_ptr<ShadowMem> *keep = nullptr)
+      : m_keep(keep) {}
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
+};
 
 class StripShadowMemNewPmPass : public llvm::PassInfoMixin<StripShadowMemNewPmPass> {
 public:

--- a/include/seadsa/TargetLibraryInfoGetter.hh
+++ b/include/seadsa/TargetLibraryInfoGetter.hh
@@ -12,6 +12,9 @@ namespace llvm {
 class Function;
 class TargetLibraryInfo;
 class TargetLibraryInfoWrapperPass;
+class Module;
+template <typename IRUnitT, typename... ExtraArgTs> class AnalysisManager;
+using ModuleAnalysisManager = AnalysisManager<Module>;
 } // namespace llvm
 
 namespace seadsa {
@@ -21,4 +24,7 @@ using TargetLibraryInfoGetter =
 /// Adapt a legacy TargetLibraryInfoWrapperPass into a getter (the wrapper must
 /// outlive the returned getter).
 TargetLibraryInfoGetter mkTLIGetter(llvm::TargetLibraryInfoWrapperPass &W);
+/// new-PM variant: serves TLI from the module's FunctionAnalysisManager
+TargetLibraryInfoGetter mkTLIGetter(llvm::Module &M,
+                                    llvm::ModuleAnalysisManager &MAM);
 } // namespace seadsa

--- a/lib/seadsa/AllocSiteInfo.cc
+++ b/lib/seadsa/AllocSiteInfo.cc
@@ -44,10 +44,20 @@ void AllocSiteInfo::getAnalysisUsage(AnalysisUsage &AU) const {
 
 bool AllocSiteInfo::runOnModule(Module &M) {
   auto &tliWrapper = getAnalysis<TargetLibraryInfoWrapperPass>();
-  m_dl = &M.getDataLayout();
-  m_awi = &getAnalysis<AllocWrapInfo>();
+  auto &awi = getAnalysis<AllocWrapInfo>();
+  awi.initialize(M, this);
+  return runImpl(
+      M,
+      [&tliWrapper](const llvm::Function &F) -> const llvm::TargetLibraryInfo & {
+        return tliWrapper.getTLI(const_cast<llvm::Function &>(F));
+      },
+      awi);
+}
 
-  m_awi->initialize(M, this);
+bool AllocSiteInfo::runImpl(Module &M, TargetLibraryInfoGetter getTLI,
+                            AllocWrapInfo &awi) {
+  m_dl = &M.getDataLayout();
+  m_awi = &awi;
   
   bool changed = false;
 
@@ -58,7 +68,7 @@ bool AllocSiteInfo::runOnModule(Module &M) {
                            << "\n");
       continue;
     }
-    m_tli = &tliWrapper.getTLI(fn);
+    m_tli = &getTLI(fn);
 
     ASI_LOG(llvm::errs() << "Running AllocSiteInfo pass on function "
                          << fn.getName() << "\n");

--- a/lib/seadsa/SeaDsaAnalysis.cc
+++ b/lib/seadsa/SeaDsaAnalysis.cc
@@ -1,3 +1,4 @@
+#include "seadsa/AllocSiteInfo.hh"
 #include "seadsa/SeaDsaAnalysis.hh"
 
 #include "seadsa/DsaAnalysis.hh" // mkGlobalAnalysis
@@ -15,7 +16,7 @@ AnalysisKey DsaInfoAnalysis::Key;
 
 // Per-function TLI from the new-PM TargetLibraryAnalysis (via the FAM proxy):
 // no legacy TargetLibraryInfoWrapperPass anywhere.
-static TargetLibraryInfoGetter mkTLIGetter(Module &M, ModuleAnalysisManager &MAM) {
+TargetLibraryInfoGetter seadsa::mkTLIGetter(Module &M, ModuleAnalysisManager &MAM) {
   auto &FAM =
       MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
   return [&FAM](const Function &F) -> const TargetLibraryInfo & {
@@ -35,6 +36,17 @@ DsaLibFuncInfoAnalysis::run(Module &M, ModuleAnalysisManager &) {
   auto dlfi = std::make_unique<DsaLibFuncInfo>();
   dlfi->initialize(M);
   return Result(std::move(dlfi));
+}
+
+AnalysisKey AllocSiteInfoAnalysis::Key;
+
+AllocSiteInfoAnalysis::Result
+AllocSiteInfoAnalysis::run(Module &M, ModuleAnalysisManager &MAM) {
+  AllocWrapInfo &awi =
+      MAM.getResult<AllocWrapInfoAnalysis>(M).getAllocWrapInfo();
+  auto asi = std::make_unique<AllocSiteInfo>();
+  asi->runImpl(M, mkTLIGetter(M, MAM), awi);
+  return Result(std::move(asi));
 }
 
 DsaInfoAnalysis::Result

--- a/lib/seadsa/ShadowMem.cc
+++ b/lib/seadsa/ShadowMem.cc
@@ -1,3 +1,4 @@
+#include "seadsa/SeaDsaAnalysis.hh"
 #include "seadsa/ShadowMem.hh"
 #include "seadsa/TargetLibraryInfoGetter.hh"
 #include "seadsa/SeaMemorySSA.hh"
@@ -233,7 +234,8 @@ class ShadowMemImpl : public InstVisitor<ShadowMemImpl> {
   seadsa::TargetLibraryInfoGetter m_getTLI;
   const DataLayout *m_dl;
   CallGraph *m_callGraph;
-  Pass &m_pass;
+  seadsa::DomTreeGetter m_getDT;
+  seadsa::AssumptionCacheGetter m_getAC;
 
   DenseMap<llvm::Function *, std::unique_ptr<SeaMemorySSA>> m_MemorySSAPerFunc;
 
@@ -607,11 +609,8 @@ class ShadowMemImpl : public InstVisitor<ShadowMemImpl> {
       }
     }
 
-    DominatorTree &DT =
-        m_pass.getAnalysis<llvm::DominatorTreeWrapperPass>(F).getDomTree();
-    AssumptionCache &AC =
-        m_pass.getAnalysis<llvm::AssumptionCacheTracker>().getAssumptionCache(
-            F);
+    DominatorTree &DT = m_getDT(F);
+    AssumptionCache &AC = m_getAC(F);
     PromoteMemToReg(allocas, DT, &AC);
   }
 
@@ -652,10 +651,12 @@ class ShadowMemImpl : public InstVisitor<ShadowMemImpl> {
 public:
   ShadowMemImpl(dsa::GlobalAnalysis &dsa, 
                 seadsa::TargetLibraryInfoGetter getTLI, CallGraph *cg,
-                Pass &pass, bool splitDsaNodes, bool computeReadMod,
+                seadsa::DomTreeGetter getDT, seadsa::AssumptionCacheGetter getAC,
+                bool splitDsaNodes, bool computeReadMod,
                 bool memOptimizer, bool useTBAA, bool useSNAAA)
       : m_dsa(dsa), m_getTLI(getTLI), m_dl(nullptr),
-        m_callGraph(cg), m_pass(pass), m_splitDsaNodes(splitDsaNodes),
+        m_callGraph(cg), m_getDT(std::move(getDT)), m_getAC(std::move(getAC)),
+        m_splitDsaNodes(splitDsaNodes),
         m_computeReadMod(computeReadMod), m_memOptimizer(memOptimizer),
         m_useTBAA(useTBAA), m_useSNAAA(useSNAAA) {}
 
@@ -848,10 +849,8 @@ bool ShadowMemImpl::runOnFunction(Function &F) {
   // once the function is known. The Pass Manager is not able to schedule the
   // AA's here, construct them manually as a workaround.
   AAResults results(tli);
-  DominatorTree &dt =
-      m_pass.getAnalysis<llvm::DominatorTreeWrapperPass>(F).getDomTree();
-  AssumptionCache &ac =
-      m_pass.getAnalysis<llvm::AssumptionCacheTracker>().getAssumptionCache(F);
+  DominatorTree &dt = m_getDT(F);
+  AssumptionCache &ac = m_getAC(F);
   BasicAAResult baa(*m_dl, F, tli, ac, &dt);
   // AA's need to be registered in the results object that will finish their
   // initialization.
@@ -1864,9 +1863,26 @@ ShadowMem::ShadowMem(GlobalAnalysis &dsa, AllocSiteInfo &asi/*unused*/,
                      llvm::CallGraph *cg, llvm::Pass &pass, bool splitDsaNodes,
                      bool computeReadMod, bool memOptimizer, bool useTBAA,
                      bool useSNAAA)
-    : m_impl(new ShadowMemImpl(dsa, seadsa::mkTLIGetter(tli), cg, pass, splitDsaNodes,
-                               computeReadMod, memOptimizer, useTBAA,
-                               useSNAAA)) {}
+    : m_impl(new ShadowMemImpl(
+          dsa, seadsa::mkTLIGetter(tli), cg,
+          [&pass](llvm::Function &F) -> llvm::DominatorTree & {
+            return pass.getAnalysis<llvm::DominatorTreeWrapperPass>(F)
+                .getDomTree();
+          },
+          [&pass](llvm::Function &F) -> llvm::AssumptionCache & {
+            return pass.getAnalysis<llvm::AssumptionCacheTracker>()
+                .getAssumptionCache(F);
+          },
+          splitDsaNodes, computeReadMod, memOptimizer, useTBAA, useSNAAA)) {}
+
+ShadowMem::ShadowMem(GlobalAnalysis &dsa, TargetLibraryInfoGetter getTLI,
+                     llvm::CallGraph *cg, DomTreeGetter getDT,
+                     AssumptionCacheGetter getAC, bool splitDsaNodes,
+                     bool computeReadMod, bool memOptimizer, bool useTBAA,
+                     bool useSNAAA)
+    : m_impl(new ShadowMemImpl(dsa, std::move(getTLI), cg, std::move(getDT),
+                               std::move(getAC), splitDsaNodes, computeReadMod,
+                               memOptimizer, useTBAA, useSNAAA)) {}
 
 ShadowMem::~ShadowMem() {}
 
@@ -2032,6 +2048,39 @@ INITIALIZE_PASS_END(StripShadowMemPass, "strip-shadow-sea-dsa",
                     "Remove shadow.mem pseudo-functions", false, false)
 
 // --- new pass manager wrapper (StripShadowMem is analysis-free) ---
+llvm::PreservedAnalyses
+seadsa::ShadowMemNewPmPass::run(llvm::Module &M,
+                                llvm::ModuleAnalysisManager &MAM) {
+  if (M.begin() == M.end()) return llvm::PreservedAnalyses::all();
+  // alloc-site marking side effect + info
+  MAM.getResult<AllocSiteInfoAnalysis>(M);
+  GlobalAnalysis &dsa =
+      MAM.getResult<DsaInfoAnalysis>(M).getGlobalAnalysis();
+  llvm::CallGraph &cg = MAM.getResult<llvm::CallGraphAnalysis>(M);
+  // The impl interleaves CFG mutation with repeated DT/AC queries; the legacy
+  // pass recomputed them fresh on every getAnalysis call, so serve FRESH
+  // trees here as well (a FAM-cached result would go stale mid-run).
+  auto dtStore =
+      std::make_shared<std::vector<std::unique_ptr<llvm::DominatorTree>>>();
+  auto acStore =
+      std::make_shared<std::vector<std::unique_ptr<llvm::AssumptionCache>>>();
+  auto sm = std::make_unique<ShadowMem>(
+      dsa, mkTLIGetter(M, MAM), &cg,
+      [dtStore](llvm::Function &F) -> llvm::DominatorTree & {
+        dtStore->push_back(std::make_unique<llvm::DominatorTree>(F));
+        return *dtStore->back();
+      },
+      [acStore](llvm::Function &F) -> llvm::AssumptionCache & {
+        acStore->push_back(std::make_unique<llvm::AssumptionCache>(F));
+        return *acStore->back();
+      },
+      SplitFields, LocalReadMod, ShadowMemOptimize, ShadowMemUseTBAA,
+      ShadowMemUseSNAAA);
+  sm->runOnModule(M);
+  if (m_keep) *m_keep = std::move(sm);
+  return llvm::PreservedAnalyses::none();
+}
+
 llvm::PreservedAnalyses
 seadsa::StripShadowMemNewPmPass::run(llvm::Module &M,
                                      llvm::ModuleAnalysisManager &) {


### PR DESCRIPTION
Give ShadowMem a new-PM face alongside the legacy pass, mirroring StripShadowMemNewPmPass. ShadowMemImpl's Pass reference becomes DominatorTree/AssumptionCache getters (the legacy ctor adapts via getAnalysis lambdas; a new ShadowMem ctor takes getters directly). The new-PM pass serves DT/AC as FRESHLY built trees per query: the impl interleaves CFG mutation with repeated lookups, so a FAM-cached result goes stale mid-run (caught as a PromoteMemToReg crash). AllocSiteInfo gets a shared runImpl and a module analysis wrapper; DsaInfoAnalysis::Result exposes its GlobalAnalysis; the (Module, MAM) TLI getter factory is promoted to shared API.

Verified: seahorn's sea smt output is byte-identical between the legacy and new-PM routes; opsem2 42/42, opsem 125 + 1 xfail, simple/solve/cex at baseline through the new route.


Claude-Session: https://claude.ai/code/session_01Cy5J4Rx9YZSDUJp8wfRfqF