### PR TITLE
Clean up foreign nodes in CS top-down propagation

### DIFF
--- a/include/seadsa/TopDown.hh
+++ b/include/seadsa/TopDown.hh
@@ -29,6 +29,7 @@ public:
   static void cloneAndResolveArguments(const DsaCallSite &CS, Graph &callerG,
                                        Graph &calleeG, bool flowSensitiveOpt = true, 
 				       bool noescape = true);
+  static void removeForeignNodes(Graph &graph);
 
   TopDownAnalysis(llvm::CallGraph &cg,
 		  bool flowSensitiveOpt = true,

--- a/include/seadsa/TopDown.hh
+++ b/include/seadsa/TopDown.hh
@@ -29,6 +29,8 @@ public:
   static void cloneAndResolveArguments(const DsaCallSite &CS, Graph &callerG,
                                        Graph &calleeG, bool flowSensitiveOpt = true, 
 				       bool noescape = true);
+  // Graph::removeNodes calls remove_dead(), which requires a compressed graph.
+  // Keep that precondition inside the helper so every caller is safe.
   static void removeForeignNodes(Graph &graph);
 
   TopDownAnalysis(llvm::CallGraph &cg,

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -526,6 +526,11 @@ void ContextSensitiveGlobalAnalysis::propagateTopDown(const DsaCallSite &cs,
   const bool noescape = true;
   TopDownAnalysis::cloneAndResolveArguments(cs, callerG, calleeG,
                                             flowSensitiveOpt, noescape);
+  calleeG.compress();
+  // Cloning marks caller-only nodes as foreign; nodes unified with native
+  // callee state lose that marker. Match the regular top-down analysis by
+  // discarding the remaining context-only copies after each propagation.
+  TopDownAnalysis::removeForeignNodes(calleeG);
 
   LOG(
       "dsa-global", if (decidePropagation(cs, calleeG, callerG) == DOWN) {

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -526,10 +526,9 @@ void ContextSensitiveGlobalAnalysis::propagateTopDown(const DsaCallSite &cs,
   const bool noescape = true;
   TopDownAnalysis::cloneAndResolveArguments(cs, callerG, calleeG,
                                             flowSensitiveOpt, noescape);
-  calleeG.compress();
-  // Cloning marks caller-only nodes as foreign; nodes unified with native
-  // callee state lose that marker. Match the regular top-down analysis by
-  // discarding the remaining context-only copies after each propagation.
+  // As in regular top-down analysis, discard caller-only context copies after
+  // each propagation. The helper compresses first to satisfy remove_dead()'s
+  // precondition, including resolution of call-site cells.
   TopDownAnalysis::removeForeignNodes(calleeG);
 
   LOG(

--- a/lib/seadsa/DsaTopDown.cc
+++ b/lib/seadsa/DsaTopDown.cc
@@ -114,6 +114,11 @@ void TopDownAnalysis::cloneAndResolveArguments(const DsaCallSite &cs,
   // Don't compress here -- caller should take care of it.
 }
 
+void TopDownAnalysis::removeForeignNodes(Graph &graph) {
+  if (!NoTDCopyingOpt)
+    graph.removeNodes([](const Node *n) { return n->isForeign(); });
+}
+
 bool TopDownAnalysis::runOnModule(Module &M, GraphMap &graphs) {
   LOG("dsa-td", errs() << "Started top-down analysis ... \n");
 
@@ -201,9 +206,7 @@ bool TopDownAnalysis::runOnModule(Module &M, GraphMap &graphs) {
                                  m_flowSensitiveOpt & !NoTDFlowSensitiveOpt,
                                  m_noescape);
 
-        // remove foreign nodes
-        if (!NoTDCopyingOpt)
-          calleeG.removeNodes([](const Node *n) { return n->isForeign(); });
+        removeForeignNodes(calleeG);
 
         LOG("dsa-td", llvm::errs()
                           << "\tCallee size after clone: " << calleeG.numNodes()

--- a/lib/seadsa/DsaTopDown.cc
+++ b/lib/seadsa/DsaTopDown.cc
@@ -115,8 +115,10 @@ void TopDownAnalysis::cloneAndResolveArguments(const DsaCallSite &cs,
 }
 
 void TopDownAnalysis::removeForeignNodes(Graph &graph) {
-  if (!NoTDCopyingOpt)
+  if (!NoTDCopyingOpt) {
+    graph.compress();
     graph.removeNodes([](const Node *n) { return n->isForeign(); });
+  }
 }
 
 bool TopDownAnalysis::runOnModule(Module &M, GraphMap &graphs) {

--- a/lib/seadsa/Graph.cc
+++ b/lib/seadsa/Graph.cc
@@ -972,7 +972,7 @@ void Graph::remove_dead() {
   m_nodes.erase(
       std::remove_if(
           m_nodes.begin(), m_nodes.end(),
-          [reachable](const std::unique_ptr<Node, DsaAllocatorDeleter> &n) {
+          [&reachable](const std::unique_ptr<Node, DsaAllocatorDeleter> &n) {
             LOG("dsa-dead", if (reachable.count(&*n) == 0) errs()
                                 << "\tremoving dead " << &*n << "\n";);
             return (reachable.count(&*n) == 0);


### PR DESCRIPTION
## Summary

- factor the regular top-down foreign-node cleanup into a reusable helper
- make the helper compress the graph before removal, satisfying `remove_dead()`'s precondition
- apply the same cleanup after context-sensitive top-down propagation
- avoid copying the reachable-node set in `remove_dead()`'s erase predicate

## Rationale

Top-down cloning marks caller-only nodes as foreign. The regular top-down analysis removes those nodes after resolving arguments, but the context-sensitive global analysis did not. As its fixed point iterated, these context-only copies accumulated in callee graphs and substantially inflated the memory regions generated by SMACK.

Nodes unified with native callee nodes lose the foreign marker through `NodeType::join`, so removing the remaining foreign nodes preserves propagated callee state while discarding caller-only copies.

`Graph::removeNodes` invokes `remove_dead()`, whose documented precondition requires a compressed graph. Compression resolves forwarding references in scalar, formal, return, link, and call-site cells before forwarding nodes are erased. `removeForeignNodes` now establishes that invariant itself, protecting both the regular and context-sensitive top-down callers.

## Validation

- assertion-enabled build verified to contain no `-DNDEBUG`; SeaDsa sanity checks enabled
- SeaDsa unit tests: 8/8 passed
- SeaDsa lit tests: 49/49 active tests passed, with the two existing expected failures unchanged
- SMACK `c/basic`: 528/528 configurations passed using a Debug build
- the full SMACK CI matrix passed before this follow-up; CI is rerunning on the updated commits
