### PR TITLE
 Port sea-dsa to LLVM 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,13 @@ option (SEA_DSA_STATIC_EXE "Static executable." OFF)
 
 ## llvm
 if (TOP_LEVEL)
-  find_package (LLVM 16.0 CONFIG)
+  find_package (LLVM 17.0 CONFIG)
   if (NOT LLVM_FOUND)
     ExternalProject_Get_Property (llvm INSTALL_DIR)
     set (LLVM_ROOT ${INSTALL_DIR})
     set (LLVM_DIR ${LLVM_ROOT}/lib/cmake/llvm CACHE PATH
       "Forced location of LLVM cmake config" FORCE)
-    message (WARNING "No llvm found. Install LLVM 16.")
+    message (WARNING "No llvm found. Install LLVM 17.")
     return()
   endif()
 

--- a/include/seadsa/CompleteCallGraph.hh
+++ b/include/seadsa/CompleteCallGraph.hh
@@ -11,6 +11,7 @@
 #include "seadsa/Graph.hh"
 
 #include <memory>
+#include <set>
 #include <vector>
 
 namespace llvm {

--- a/lib/seadsa/CallGraphWrapper.cc
+++ b/lib/seadsa/CallGraphWrapper.cc
@@ -1,5 +1,5 @@
 #include "llvm/ADT/SCCIterator.h"
-#include "llvm/ADT/Optional.h"
+#include <optional>
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -1,4 +1,4 @@
-#include "llvm/ADT/Optional.h"
+#include <optional>
 #include "llvm/ADT/SCCIterator.h"
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Analysis/LoopInfo.h"


### PR DESCRIPTION
## Why

This moves sea-dsa from LLVM 16 to LLVM 17, onto the `dev17` branch.
The base branch `dev17` is pristine: it equals the current `dev16`
head (including the new-PM `ShadowMemNewPmPass` work), so this PR
shows only the 16→17 delta — which turned out to be very small.

## What changed (two commits)

1. **`build(llvm17): require LLVM 17`** — bump `find_package` to
   LLVM 17.0.
2. **`fix(llvm17): drop removed Optional.h include and add missing
   <set>`** — LLVM 17 removed `llvm/ADT/Optional.h` (it had been just
   a `std::optional` alias since 16), so the remaining includes become
   `<optional>`; and `CompleteCallGraph.hh` needs a direct
   `#include <set>` that previously arrived transitively through LLVM
   headers.

No functional code changes: everything else in sea-dsa compiles and
behaves identically under LLVM 17.


Built clean (zero errors) against clang+llvm-17.0.6.

- **Regression suite (lit)**: identical results to the dev16 baseline
  — the same 30 tests pass and the same 22 tests fail on both the
  dev16 and dev17 binaries (those 22 failures pre-date this PR and are
  unrelated to LLVM 17; they are tracked separately). Note for anyone
  running the suite locally: `tests/check_graphs.py` requires
  `pygraphviz`; without it installed the graph-comparison step crashes
  and ~46 tests report as failing on any binary.
- **Graph equivalence (the strong gate)**: all 63 memory/callgraph dot
  files emitted by the dev16 and dev17 binaries over the test corpus
  are label-isomorphic per the repo's own `check_graphs.py both`
  comparison (63/63). Raw dot output cannot be diffed directly — node
  IDs are heap addresses and emission order is unstable run-to-run —
  so isomorphism is the meaningful comparison.
- **Unit tests** (`units_sea_dsa`): 7/8, with the single failure
  (`FirstPrimT.LL_reverse`) reproduced identically on a dev16 + LLVM 16
  baseline build — it is a pre-existing opaque-pointer-era issue in
  `GetFirstPrimitiveTy` on self-referential structs, not an LLVM 17
  regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy5J4Rx9YZSDUJp8wfRfqF