### PR TITLE
 Port sea-dsa to LLVM 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,13 @@ option (SEA_DSA_STATIC_EXE "Static executable." OFF)
 
 ## llvm
 if (TOP_LEVEL)
-  find_package (LLVM 17.0 CONFIG)
+  find_package (LLVM 18.1 CONFIG)
   if (NOT LLVM_FOUND)
     ExternalProject_Get_Property (llvm INSTALL_DIR)
     set (LLVM_ROOT ${INSTALL_DIR})
     set (LLVM_DIR ${LLVM_ROOT}/lib/cmake/llvm CACHE PATH
       "Forced location of LLVM cmake config" FORCE)
-    message (WARNING "No llvm found. Install LLVM 17.")
+    message (WARNING "No llvm found. Install LLVM 18.")
     return()
   endif()
 

--- a/include/seadsa/SeaDsaAliasAnalysis.hh
+++ b/include/seadsa/SeaDsaAliasAnalysis.hh
@@ -73,4 +73,18 @@ public:
 };
 
 llvm::ImmutablePass *createSeaDsaAAWrapperPass();
+
+/// New-PM function analysis whose Result is SeaDsaAAResult. Register it in an
+/// AAManager ahead of the default pipeline (mirroring the legacy
+/// ExternalAAWrapperPass ordering) to expose seadsa to AAEvaluator and other
+/// new-PM AA consumers. Requires AllocWrapInfoAnalysis and
+/// DsaLibFuncInfoAnalysis results to be cached in the module analysis manager.
+class SeaDsaAA : public llvm::AnalysisInfoMixin<SeaDsaAA> {
+  friend llvm::AnalysisInfoMixin<SeaDsaAA>;
+  static llvm::AnalysisKey Key;
+
+public:
+  using Result = SeaDsaAAResult;
+  Result run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM);
+};
 } // namespace seadsa

--- a/lib/seadsa/AllocSiteInfo.cc
+++ b/lib/seadsa/AllocSiteInfo.cc
@@ -109,8 +109,8 @@ std::optional<unsigned> AllocSiteInfo::maybeEvalAllocSize(Value &v,
   Opts.EvalMode = llvm::ObjectSizeOpts::Mode::Max;
   ObjectSizeOffsetVisitor OSOV(*m_dl, m_tli, ctx, Opts);
   auto OffsetAlign = OSOV.compute(&v);
-  if (OSOV.knownSize(OffsetAlign)) {
-    const int64_t sz = OffsetAlign.first.getSExtValue();
+  if (OffsetAlign.knownSize()) {
+    const int64_t sz = OffsetAlign.Size.getSExtValue();
     assert(sz >= 0);
     bytes = unsigned(sz);
   }

--- a/lib/seadsa/Cloner.cc
+++ b/lib/seadsa/Cloner.cc
@@ -24,7 +24,7 @@ static bool isConstantNoPtr(const llvm::Value *v) {
     return false;
 
   // Cheaply check if the global value has a string-like name.
-  if (v->hasName() && v->getName().startswith(".str."))
+  if (v->hasName() && v->getName().starts_with(".str."))
     return true;
 
   if (!v->getType()->isPointerTy()) return false;

--- a/lib/seadsa/DsaLibFuncInfo.cc
+++ b/lib/seadsa/DsaLibFuncInfo.cc
@@ -257,7 +257,7 @@ void DsaLibFuncInfo::generateSpec(const llvm::Function &F,
 
   // sets the attributes that the original node has onto the spec graph value
   auto setAttributes = [&](const Node *gNode, Value *specVal) {
-    auto bitCastVal = builder.CreateBitCast(specVal, builder.getInt8PtrTy());
+    auto bitCastVal = builder.CreateBitCast(specVal, builder.getPtrTy());
 
     if (gNode->isModified()) { builder.CreateCall(specFnModify, bitCastVal); }
     if (gNode->isHeap()) { builder.CreateCall(specFnHeap, bitCastVal); }
@@ -281,7 +281,7 @@ void DsaLibFuncInfo::generateSpec(const llvm::Function &F,
     if (!G->hasCell(*fIt)) continue;
 
     Value &v = *specIt;
-    Value *castVal = builder.CreateBitCast(&v, builder.getInt8PtrTy());
+    Value *castVal = builder.CreateBitCast(&v, builder.getPtrTy());
     visitStack.push({G->getCell(*fIt).getNode(), castVal});
   }
 
@@ -317,7 +317,7 @@ void DsaLibFuncInfo::generateSpec(const llvm::Function &F,
           castChild = builder.CreateBitCast(newNodeVal, ty);
         else
           castChild = builder.CreateBitCast(
-              newNodeVal, llvm::Type::getInt8PtrTy(m_specModule->getContext()));
+              newNodeVal, llvm::PointerType::getUnqual(m_specModule->getContext()));
         builder.CreateCall(linkFn, {specVal, llvmOffset, castChild});
 
         visitStack.push({link.second->getNode(), newNodeVal});

--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -280,7 +280,7 @@ class GlobalBuilder : public BlockBuilderBase {
 
     if (const ConstantVector *CP = dyn_cast<ConstantVector>(Init)) {
       unsigned ElementSize =
-          m_dl.getTypeAllocSize(CP->getType()->getElementType()).getFixedSize();
+          m_dl.getTypeAllocSize(CP->getType()->getElementType()).getFixedValue();
       for (unsigned i = 0, e = CP->getNumOperands(); i != e; ++i) {
         unsigned noffset = offset + i * ElementSize;
         seadsa::Cell nc = seadsa::Cell(c.getNode(), noffset);
@@ -294,7 +294,7 @@ class GlobalBuilder : public BlockBuilderBase {
     if (const ConstantArray *CPA = dyn_cast<ConstantArray>(Init)) {
       unsigned ElementSize =
           m_dl.getTypeAllocSize(CPA->getType()->getElementType())
-              .getFixedSize();
+              .getFixedValue();
       for (unsigned i = 0, e = CPA->getNumOperands(); i != e; ++i) {
         unsigned noffset = offset + i * ElementSize;
         seadsa::Cell nc = seadsa::Cell(c.getNode(), noffset);
@@ -514,9 +514,9 @@ class IntraBlockBuilder : public InstVisitor<IntraBlockBuilder>,
     // may need to define multiple sea_dsa_link types. For example:
     // sea_dsa_link_to_charptr(const void *p, unsigned offset, const char*
     // p2);
-    if (fn->getName().startswith("sea_dsa_link"))
+    if (fn->getName().starts_with("sea_dsa_link"))
       fnType = SeadsaFn::LINK;
-    else if (fn->getName().startswith("sea_dsa_access"))
+    else if (fn->getName().starts_with("sea_dsa_access"))
       fnType = SeadsaFn::ACCESS;
 
     return fnType;
@@ -526,7 +526,7 @@ class IntraBlockBuilder : public InstVisitor<IntraBlockBuilder>,
   static bool isSeaDsaFn(const Function *fn) {
     if (!fn) return false;
     auto n = fn->getName();
-    return n.startswith("sea_dsa_");
+    return n.starts_with("sea_dsa_");
   }
 
   /// Returns true if \p F is a \p ownsem_ family of functions
@@ -1202,7 +1202,7 @@ void IntraBlockBuilder::visitExternalCall(CallBase &I) {
   Cell &c = m_graph.mkCell(I, Cell(m_graph.mkNode(), 0));
   c.getNode()->setExternal();
 
-  if (callee->getName().startswith("verifier.nondet.abstract.memory")) return;
+  if (callee->getName().starts_with("verifier.nondet.abstract.memory")) return;
 
   // TODO: better handling of external funcations
   // TOOD: Use function attributes and external specifications
@@ -1684,7 +1684,7 @@ bool BlockBuilderBase::isFixedOffset(const IntToPtrInst &inst, Value *&base,
       }
       offset = C->getZExtValue();
     } else if (auto *LI = dyn_cast<LoadInst>(X)) {
-      PointerType *liType = Type::getInt8PtrTy(LI->getContext());
+      PointerType *liType = PointerType::getUnqual(LI->getContext());
       seadsa::Cell ptrCell =
           valueCell(*LI->getPointerOperand()->stripPointerCasts());
       ptrCell.addAccessedType(0, liType);
@@ -1812,7 +1812,7 @@ bool isEscapingPtrToInt(const PtrToIntInst &def) {
           // to it if (callee->doesNotAccessMemory())
           //   continue;
           auto n = callee->getName();
-          if (n.startswith("__sea_set_extptr_slot") ||
+          if (n.starts_with("__sea_set_extptr_slot") ||
               n.equals("verifier.assume") || n.equals("llvm.assume"))
             continue;
         }

--- a/lib/seadsa/RemovePtrToInt.cc
+++ b/lib/seadsa/RemovePtrToInt.cc
@@ -62,8 +62,8 @@ visitIntStoreInst(StoreInst *SI, Function &F, const DataLayout &DL,
 
   IRBuilder<> IRB(LI);
 
-  auto *Int8PtrPtrTy = Type::getInt8PtrTy(SI->getContext())->getPointerTo();
-  auto newLI = IRB.CreateLoad(Type::getInt8PtrTy(SI->getContext()),
+  auto *Int8PtrPtrTy = PointerType::getUnqual(SI->getContext())->getPointerTo();
+  auto newLI = IRB.CreateLoad(PointerType::getUnqual(SI->getContext()),
                               IRB.CreateBitCast(loadAddr, Int8PtrPtrTy));
   if (LI->hasName()) newLI->setName(LI->getName());
   newLI->setAlignment(LI->getAlign());
@@ -111,7 +111,7 @@ visitIntStoreInst2(StoreInst *SI, Function &F, const DataLayout &DL,
 
   IRBuilder<> IRB(SI);
 
-  auto *Int8PtrTy = Type::getInt8PtrTy(SI->getContext());
+  auto *Int8PtrTy = PointerType::getUnqual(SI->getContext());
   auto *Int8PtrPtrTy = Int8PtrTy->getPointerTo();
 
   auto *val = P2I->getPointerOperand();
@@ -246,7 +246,7 @@ public:
 
     IRBuilder<> IRB(&I);
 
-    ptr = IRB.CreateBitCast(ptr, IRB.getInt8PtrTy());
+    ptr = IRB.CreateBitCast(ptr, IRB.getPtrTy());
     auto *gep = IRB.CreateGEP(IRB.getInt8Ty(), ptr, I.getOperand(1));
     return gep;
   }
@@ -433,8 +433,8 @@ bool RemovePtrToInt::runImpl(Function &F, DominatorTree &DT) {
   if (F.isDeclaration()) return false;
 
   // Skip special functions
-  if (F.getName().startswith("seahorn.") || F.getName().startswith("shadow.") ||
-      F.getName().startswith("verifier."))
+  if (F.getName().starts_with("seahorn.") || F.getName().starts_with("shadow.") ||
+      F.getName().starts_with("verifier."))
     return false;
 
   DOG(errs() << "\n~~~~~~~ Begin of RP2I on " << F.getName() << " ~~~~~ \n");

--- a/lib/seadsa/SeaDsaAliasAnalysis.cc
+++ b/lib/seadsa/SeaDsaAliasAnalysis.cc
@@ -1,4 +1,6 @@
 #include "seadsa/SeaDsaAliasAnalysis.hh"
+#include "seadsa/SeaDsaAnalysis.hh"
+#include "llvm/Analysis/TargetLibraryInfo.h"
 
 #include "seadsa/AllocWrapInfo.hh"
 #include "seadsa/DsaLibFuncInfo.hh"
@@ -214,6 +216,26 @@ void SeaDsaAAWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.addRequired<TargetLibraryInfoWrapperPass>();
   AU.addRequired<AllocWrapInfo>();
   AU.addRequired<DsaLibFuncInfo>();
+}
+
+llvm::AnalysisKey SeaDsaAA::Key;
+
+SeaDsaAA::Result SeaDsaAA::run(llvm::Function &F,
+                               llvm::FunctionAnalysisManager &FAM) {
+  auto &MAMProxy = FAM.getResult<llvm::ModuleAnalysisManagerFunctionProxy>(F);
+  llvm::Module &M = *F.getParent();
+  auto *AWI = MAMProxy.getCachedResult<AllocWrapInfoAnalysis>(M);
+  auto *DLFI = MAMProxy.getCachedResult<DsaLibFuncInfoAnalysis>(M);
+  assert(AWI && DLFI &&
+         "AllocWrapInfoAnalysis and DsaLibFuncInfoAnalysis "
+         "must be run before SeaDsaAA");
+  TargetLibraryInfoGetter getTLI =
+      [&FAM](const llvm::Function &Fn) -> const llvm::TargetLibraryInfo & {
+    return FAM.getResult<llvm::TargetLibraryAnalysis>(
+        const_cast<llvm::Function &>(Fn));
+  };
+  return SeaDsaAAResult(getTLI, AWI->getAllocWrapInfo(),
+                        DLFI->getDsaLibFuncInfo());
 }
 } // namespace seadsa
 

--- a/lib/seadsa/ShadowMem.cc
+++ b/lib/seadsa/ShadowMem.cc
@@ -103,9 +103,9 @@ Value *getUniqueScalar(LLVMContext &ctx, IRBuilder<> &B, const dsa::Cell &c) {
     // -- are probably not very common.
     if (auto *gv = dyn_cast_or_null<GlobalVariable>(v))
       if (gv->getValueType()->isSingleValueType())
-        return B.CreateBitCast(v, Type::getInt8PtrTy(ctx));
+        return B.CreateBitCast(v, PointerType::getUnqual(ctx));
   }
-  return ConstantPointerNull::get(Type::getInt8PtrTy(ctx));
+  return ConstantPointerNull::get(PointerType::getUnqual(ctx));
 }
 
 /// Computes the set of notes reachable from \p n
@@ -516,7 +516,7 @@ class ShadowMemImpl : public InstVisitor<ShadowMemImpl> {
     Value *scalar = getUniqueScalar(*m_llvmCtx, B, c);
     if (!isa<ConstantPointerNull>(scalar)) return nullptr;
 
-    Value *u = B.CreateBitCast(&_u, Type::getInt8PtrTy(*m_llvmCtx));
+    Value *u = B.CreateBitCast(&_u, PointerType::getUnqual(*m_llvmCtx));
     AllocaInst *v = getShadowForField(c);
     auto *ci = mkShadowCall(
         B, c, m_memGlobalVarInitFn,
@@ -1075,10 +1075,10 @@ void ShadowMemImpl::visitCallBase(CallBase &I) {
   auto *callee = I.getCalledFunction();
   if (!callee) return;
 
-  if ((callee->getName().startswith("seahorn.") ||
-       callee->getName().startswith("verifier.")) &&
+  if ((callee->getName().starts_with("seahorn.") ||
+       callee->getName().starts_with("verifier.")) &&
       /* seahorn.bounce should be treated as a regular function*/
-      !(callee->getName().startswith("seahorn.bounce")))
+      !(callee->getName().starts_with("seahorn.bounce")))
     return;
 
 
@@ -1517,7 +1517,7 @@ Constant *getOrInsertFunction(Module &M, StringRef Name, Type *RetTy,
 void ShadowMemImpl::mkShadowFunctions(Module &M) {
   LLVMContext &ctx = M.getContext();
   m_Int32Ty = Type::getInt32Ty(ctx);
-  Type *i8PtrTy = Type::getInt8PtrTy(ctx);
+  Type *i8PtrTy = PointerType::getUnqual(ctx);
   Type *voidTy = Type::getVoidTy(ctx);
 
   m_memLoadFn = getOrInsertFunction(M, m_memLoadTag, voidTy, m_Int32Ty,

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   irreader
   bitwriter
   analysis
+  passes
   ipo
   scalaropts
   instrumentation

--- a/tools/seadsa.cc
+++ b/tools/seadsa.cc
@@ -220,7 +220,10 @@ int main(int argc, char **argv) {
       pass_manager.add(seadsa::createDsaCallGraphPrinterPass());
     }
 
-    if (AAEval) { pass_manager.add(llvm::createAAEvalPass()); }
+    if (AAEval) {
+      // llvm::createAAEvalPass() (legacy AA-eval) was removed in LLVM 18.
+      llvm::errs() << "warning: --aa-eval is unsupported under LLVM 18\n";
+    }
 
     if (!MemDot && !MemViewer && !seadsa::PrintDsaStats &&
         !seadsa::PrintCallGraphStats && !CallGraphDot && !AAEval) {

--- a/tools/seadsa.cc
+++ b/tools/seadsa.cc
@@ -2,6 +2,8 @@
 // seadsda -- Print heap graphs and call graph computed by sea-dsa
 ///
 
+#include "llvm/Analysis/AliasAnalysisEvaluator.h"
+#include "llvm/Analysis/BasicAliasAnalysis.h"
 #include "llvm/Analysis/CallPrinter.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -10,6 +12,7 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/LinkAllPasses.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
@@ -27,6 +30,7 @@
 #include "seadsa/DsaLibFuncInfo.hh"
 #include "seadsa/InitializePasses.hh"
 #include "seadsa/SeaDsaAliasAnalysis.hh"
+#include "seadsa/SeaDsaAnalysis.hh"
 #include "seadsa/ShadowMem.hh"
 #include "seadsa/support/Debug.h"
 #include "seadsa/support/RemovePtrToInt.hh"
@@ -220,10 +224,8 @@ int main(int argc, char **argv) {
       pass_manager.add(seadsa::createDsaCallGraphPrinterPass());
     }
 
-    if (AAEval) {
-      // llvm::createAAEvalPass() (legacy AA-eval) was removed in LLVM 18.
-      llvm::errs() << "warning: --aa-eval is unsupported under LLVM 18\n";
-    }
+    // AAEval runs after the legacy pipeline below: llvm::createAAEvalPass()
+    // (legacy AA-eval) was removed in LLVM 18, so it goes through the new PM.
 
     if (!MemDot && !MemViewer && !seadsa::PrintDsaStats &&
         !seadsa::PrintCallGraphStats && !CallGraphDot && !AAEval) {
@@ -238,6 +240,38 @@ int main(int argc, char **argv) {
     pass_manager.add(createPrintModulePass(asmOutput->os()));
 
   pass_manager.run(*module.get());
+
+  if (AAEval && !RunShadowMem) {
+    // The legacy createAAEvalPass() was removed in LLVM 18; run the new-PM
+    // AAEvaluator instead, with seadsa's AA registered ahead of the default
+    // chain (mirroring the legacy ExternalAAWrapperPass ordering). The
+    // aggregate report prints when the evaluator is destroyed.
+    llvm::PassBuilder PB;
+    llvm::LoopAnalysisManager LAM;
+    llvm::FunctionAnalysisManager FAM;
+    llvm::CGSCCAnalysisManager CGAM;
+    llvm::ModuleAnalysisManager MAM;
+    FAM.registerPass([] {
+      llvm::AAManager AA;
+      AA.registerFunctionAnalysis<seadsa::SeaDsaAA>();
+      AA.registerFunctionAnalysis<llvm::BasicAA>();
+      return AA;
+    });
+    FAM.registerPass([] { return seadsa::SeaDsaAA(); });
+    MAM.registerPass([] { return seadsa::AllocWrapInfoAnalysis(); });
+    MAM.registerPass([] { return seadsa::DsaLibFuncInfoAnalysis(); });
+    PB.registerModuleAnalyses(MAM);
+    PB.registerCGSCCAnalyses(CGAM);
+    PB.registerFunctionAnalyses(FAM);
+    PB.registerLoopAnalyses(LAM);
+    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+    // prime the module-level seadsa inputs SeaDsaAA reads via cached results
+    MAM.getResult<seadsa::AllocWrapInfoAnalysis>(*module);
+    MAM.getResult<seadsa::DsaLibFuncInfoAnalysis>(*module);
+    llvm::ModulePassManager MPM;
+    MPM.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::AAEvaluator()));
+    MPM.run(*module, MAM);
+  }
 
   if (!AsmOutputFilename.empty()) asmOutput->keep();
 


### PR DESCRIPTION
# Why

This moves sea-dsa from LLVM 17 to LLVM 18, onto the `dev18` branch.
The base branch `dev18` is pristine (= the current `dev17` head), so
this PR shows only the 17→18 delta.

## What changed (three commits)

1. **`build(llvm18): require LLVM 18.1`** — `find_package(LLVM 18.1)`;
   18 ships only as 18.1.x, so plain `18` does not match.
2. **`fix(llvm18): port to LLVM 18 APIs`** — mechanical renames
   (`startswith`→`starts_with` etc.) across seven files.
3. **`feat(newpm): add SeaDsaAA analysis; port --sea-dsa-aa-eval to new
   PM`** — LLVM 18 removed the legacy `createAAEvalPass()`. Instead of
   stubbing the flag out, this adds a new-PM `SeaDsaAA` function
   analysis (Result = the existing `SeaDsaAAResult`, built from the
   cached `AllocWrapInfoAnalysis`/`DsaLibFuncInfoAnalysis` module
   results) beside the legacy `SeaDsaAAWrapperPass` — the same
   additive wrapper-symmetry used for ShadowMemNewPmPass — and the
   seadsa tool runs the new-PM `AAEvaluator` with `SeaDsaAA` registered
   ahead of `BasicAA`, mirroring the legacy `ExternalAAWrapperPass`

## How this was tested

Built clean against LLVM 18.1 (apt).

- **Regression suite (lit)**: identical results to the dev17 baseline —
  same 22 pre-existing failures on both binaries, including
  `simple-aa-eval.ll` passing again through the new-PM AAEvaluator.
- **Graph equivalence**: all 63 memory/callgraph dot outputs emitted by
  the dev17 and dev18 binaries are label-isomorphic per the repo's own
  `check_graphs.py both` (63/63).
- **Unit tests**: 7/8 — the single failure (`FirstPrimT.LL_reverse`)
  is the known pre-existing opaque-pointer-era issue, identical on
  dev16/dev17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy5J4Rx9YZSDUJp8wfRfqF