### PR TITLE
fix(local): stride the first GEP index over the source element type

### DIFF
--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -891,8 +891,6 @@ std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
                                               ArrayRef<Value *> Indicies,
                                               const DataLayout &dl) {
 
-  Type *Ty = srcElementTy;
-
   // numeric offset
   int64_t noffset = 0;
 
@@ -907,13 +905,13 @@ std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
     if (StructType *STy = TI.getStructTypeOrNull()) {
       unsigned fieldNo = cast<ConstantInt>(Indicies[CurIDX])->getZExtValue();
       noffset += dl.getStructLayout(STy)->getElementOffset(fieldNo);
-      Ty = STy->getElementType(fieldNo);
     } else {
-      // We do nothing to pointer type now
-      if (Ty->isArrayTy())
-        Ty = Ty->getArrayElementType();
-      else if (auto vt = dyn_cast<VectorType>(Ty))
-        Ty = vt->getElementType();
+      // The type strided over by index CurIDX. For CurIDX == 0 that is
+      // srcElementTy itself -- the first index strides over the source
+      // element type, it does not index into it. Descending by hand here
+      // (as the pre-opaque-pointer code did, when this function received
+      // the *pointer* type) would consume the first index twice.
+      Type *Ty = TI.getIndexedType();
       assert(Ty && "Type is neither PointerType nor SequentialType");
 
       uint64_t sz = dl.getTypeStoreSize(Ty);

--- a/tests/gep_multidim.ll
+++ b/tests/gep_multidim.ll
@@ -1,0 +1,55 @@
+; RUN: %seadsa %s %ci_dsa --sea-dsa-type-aware=true --sea-dsa-dot --sea-dsa-dot-outdir=%T/gep_multidim.ll
+; RUN: cat %T/gep_multidim.ll/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=ROW1
+; RUN: cat %T/gep_multidim.ll/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=ROW5
+; RUN: cat %T/gep_multidim.ll/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=STRUCT
+; RUN: cat %T/gep_multidim.ll/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=NOSTALE
+
+; The first GEP index strides over the source element type, it does not index
+; into it. Descending into the source element type before applying index 0
+; consumes that index twice, which only shows when the source element type is
+; an aggregate: multi-dimensional arrays and arrays of structs.
+
+; @table: source element type [2 x i32] (8 bytes), so t[1][1] is at byte 12 and
+; t[5][1] at byte 44. The doubly-consumed first index would give 8 and 24.
+; ROW1: 12:i32
+; ROW5: 44:i32
+
+; @arr: source element type [4 x %struct.S] (32 bytes), so s[1][2].snd is at
+; 32 + 16 + 4 = 52. The doubly-consumed first index would give 8 + 16 + 4 = 28.
+; STRUCT: 52:i32
+
+; NOSTALE-NOT: (^|[^0-9])(8|24|28):i32
+
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+
+%struct.S = type { i32, i32 }
+
+@table = global [6 x [2 x i32]] zeroinitializer, align 4
+@arr = global [2 x [4 x %struct.S]] zeroinitializer, align 4
+
+; multi-dimensional array: t[1][1] and t[5][1]
+define internal i32 @f(ptr %t) {
+entry:
+  %p1 = getelementptr inbounds [2 x i32], ptr %t, i64 1, i64 1
+  %v1 = load i32, ptr %p1, align 4
+  %p5 = getelementptr inbounds [2 x i32], ptr %t, i64 5, i64 1
+  %v5 = load i32, ptr %p5, align 4
+  %add = add i32 %v1, %v5
+  ret i32 %add
+}
+
+; array of structs: s[1][2].snd
+define internal i32 @g(ptr %s) {
+entry:
+  %q = getelementptr inbounds [4 x %struct.S], ptr %s, i64 1, i64 2, i32 1
+  %v = load i32, ptr %q, align 4
+  ret i32 %v
+}
+
+define i32 @main() {
+entry:
+  %r1 = call i32 @f(ptr @table)
+  %r2 = call i32 @g(ptr @arr)
+  %r = add i32 %r1, %r2
+  ret i32 %r
+}


### PR DESCRIPTION
## Summary

`computeGepOffset` computes the wrong byte offset for any GEP whose source element
type is an aggregate — multi-dimensional arrays and arrays of structs. The first
index is strided over the *element* of the source element type instead of over the
source element type itself, so it is effectively consumed twice.

For `getelementptr inbounds [2 x i32], ptr %t, i64 1, i64 1` (`t[1][1]`, byte 12)
sea-dsa computes byte **8**.

One-dimensional `int*` indexing is unaffected, which is why this survived the LLVM
15 port unnoticed.

## Why this matters

This is a soundness bug, not a precision regression. sea-dsa places cells at wrong
byte offsets, so a client reads and writes the wrong memory contents and can
*prove* a false fact.

In clam `dev15`, four lit tests started reporting fewer safe checks than the LLVM
14 build. All four fail on the same assertion:

```c
uint32_t table2[6][2] = {{1,10},{2,20},{3,30},{4,40},{5,50},{6,60}};

int32_t compute2(uint32_t t[6][2]) {
  return t[0][1] + t[1][1] + t[5][1];      // 10 + 20 + 60 == 90
}
...
int w = compute2(table2);
__CRAB_assert(w == 90);                    // was OK, became a warning
```

clam 15 derives `w == 16` — a wrong value, because it read `table2[1][0]` and
`table2[3][0]` (2 and 4) instead of `table2[1][1]` and `table2[5][1]` (20 and 60).
The same mechanism can just as easily make an unsafe program verify.

The CrabIR from the two builds is identical apart from two constants in `main`'s
global-initializer expansion, which is exactly where sea-dsa cell offsets are used:

```
                                LLVM 14                  LLVM 15
  table2[1][1]      array_store(@V_5, 12, 20)   array_store(@V_5,  8, 2)
  table2[5][1]      array_store(@V_7, 44, 60)   array_store(@V_7, 24, 4)
```

clam's own `doGEP` uses `GetElementPtrInst::accumulateConstantOffset` and is not
implicated — the function body offsets are right in both builds. Only the offsets
coming from sea-dsa cells are wrong.

## Root cause

Introduced by 8248b6b ("LLVM 15 Port"). Before the port, `computeGepOffset`
received the GEP's **pointer** type, and the pointer→pointee step at the top of the
loop was precisely what index 0 means:

```cpp
Type *Ty = ptrTy;                          // e.g. [2 x i32]*
...
  if (PointerType *ptrTy = dyn_cast<PointerType>(Ty))
    Ty = ptrTy->getElementType();          // index 0: [2 x i32]* -> [2 x i32]
  else if (Ty->isArrayTy())
    Ty = Ty->getArrayElementType();        // index 1: [2 x i32]  -> i32
  uint64_t sz = dl.getTypeStoreSize(Ty);
```

Opaque pointers removed `PointerType::getElementType()`, so the port changed the
parameter to the **source element type** — but left the descent in place:

```cpp
Type *Ty = srcElementTy;                   // now already [2 x i32]
...
  // We do nothing to pointer type now
  if (Ty->isArrayTy())
    Ty = Ty->getArrayElementType();        // index 0 descends too -> i32
  uint64_t sz = dl.getTypeStoreSize(Ty);   // 4, should be 8
```

`Ty` now starts one level lower, so the first index is consumed twice. Tracing
`gep [2 x i32], ptr %t, i64 1, i64 1`:

| index | correct stride | computed stride | correct | computed |
|---|---|---|---|---|
| `1` | `[2 x i32]` = 8 | `i32` = 4 | +8 | +4 |
| `1` | `i32` = 4 | `i32` = 4 | +4 | +4 |
| | | **total** | **12** | **8** |

`gep i32, ptr %t, i64 2` is unaffected: `i32` is not an array, so no descent
happens and the stride is 4 either way.

## The fix

The iterator already tracks this correctly. `gep_type_begin(srcElementTy, Indices)`
initialises `CurTy = srcElementTy`, and `getIndexedType()` returns the type strided
over by the current index — `srcElementTy` for index 0, descending on each `++TI`.
That is what `DataLayout::getIndexedOffsetInType` uses. So take the stride from the
iterator and delete the hand-rolled descent:

```cpp
-      // We do nothing to pointer type now
-      if (Ty->isArrayTy())
-        Ty = Ty->getArrayElementType();
-      else if (auto vt = dyn_cast<VectorType>(Ty))
-        Ty = vt->getElementType();
+      Type *Ty = TI.getIndexedType();
```

`Ty` becomes local to the sequential branch, and the `Ty = STy->getElementType(...)`
assignment in the struct branch is dead once the iterator supplies the type.

## Testing

New `tests/gep_multidim.ll` covers both shapes of the bug, asserting byte offsets
that are derivable from the datalayout by hand rather than diffing against a
generated expected graph:

- `[6 x [2 x i32]]`: `t[1][1]` at 12, `t[5][1]` at 44 (would be 8 and 24).
- `[2 x [4 x %struct.S]]`: `s[1][2].snd` at `32 + 16 + 4 = 52` (would be 28).

The second case matters because a *bare* array of structs is not affected — clang
emits `gep %struct.S, ptr %s, i64 3, i32 1`, and `%struct.S` is not an array, so the
old code took no descent. An array source element type is what triggers it.

Verified with the patch stashed and recompiled both ways:

| | `@table` node | `@arr` node | test |
|---|---|---|---|
| before | `{8:i32,24:i32}` | `{28:i32}` | FAIL |
| after | `{44:i32,12:i32}` | `{52:i32}` | PASS |

sea-dsa lit suite (LLVM 15.0.7, macOS arm64): `33 -> 34` passed, 3 XFAIL, and the
same 16 pre-existing failures before and after. Those 16 are stale expected graphs —
the inputs are still typed-pointer syntax that LLVM 15 auto-upgrades on parse — and
are independent of this change.