### PR TITLE
ci: add nightly workflow; scope test workflow to main

### DIFF
--- a/.github/workflows/nightly-seadsa-docker.yml
+++ b/.github/workflows/nightly-seadsa-docker.yml
@@ -1,0 +1,37 @@
+# Nightly: build and test main and every maintained dev<N> branch.
+#
+# Each branch pins its own LLVM version inside docker/sea-dsa-builder.Dockerfile
+# (FROM seahorn/buildpack-deps-seahorn:jammy-llvm<N>), so the build needs no
+# build-args -- checking out the branch is enough. The Dockerfile also runs the
+# test-sea-dsa and sea-dsa-units targets, so a failing test fails the build.
+#
+# Images are built only to exercise the branch; nothing is pushed anywhere.
+#
+# NOTE: scheduled workflows only run from the repository's default branch, so
+# this file must live on main for the cron to fire. Add a branch below when a
+# new dev<N> is cut.
+
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, dev14, dev15, dev16, dev17, dev18]
+
+    steps:
+      - name: Check out ${{ matrix.branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Build seadsa and run tests (${{ matrix.branch }})
+        run: docker build -t seadsa-nightly:${{ matrix.branch }} -f docker/sea-dsa-builder.Dockerfile .

--- a/.github/workflows/test-seadsa-docker.yml
+++ b/.github/workflows/test-seadsa-docker.yml
@@ -2,13 +2,16 @@
 
 name: CI
 
-# Run CI on pushes to and pull requests targeting the LLVM-14 branches.
-# (dev15 is LLVM-15; add it here once main moves to a newer LLVM.)
+# Run CI on pushes to main and on pull requests targeting main.
+# Each dev<N> branch carries its own copy of this workflow, scoped to itself and
+# pinned to its own LLVM version, so listing those branches here would be a no-op:
+# GitHub resolves workflow files from the pushed branch (push) or the base branch
+# (pull_request), never from main.
 on:
   push:
-    branches: [dev14, main]
+    branches: [main]
   pull_request:
-    branches: [dev14, main]
+    branches: [main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
The test workflow listed [dev14, main] in its push and pull_request branch filters. GitHub resolves workflow files from the pushed branch (push) or the base branch (pull_request), never from main, so the dev14 entry could never match: each dev<N> branch already carries its own copy of the workflow, scoped to itself and pinned to its own LLVM version. Scope main's copy to main and record why the dev branches are absent.

Add a nightly workflow that builds and tests main and dev15..dev18 on a midnight-UTC cron, plus a manual trigger. Each branch pins its LLVM version in docker/sea-dsa-builder.Dockerfile, so a checkout of the branch is enough and no build-args are needed. Nothing is pushed to DockerHub; the images only exist to exercise the branch.

Scheduled workflows only run from the default branch, so the nightly file must land on main for the cron to fire.