### PR TITLE
fix(newpm): preserve DsaInfoAnalysis across ShadowMemNewPmPass

### DIFF
--- a/lib/seadsa/ShadowMem.cc
+++ b/lib/seadsa/ShadowMem.cc
@@ -2078,7 +2078,15 @@ seadsa::ShadowMemNewPmPass::run(llvm::Module &M,
       ShadowMemUseSNAAA);
   sm->runOnModule(M);
   if (m_keep) *m_keep = std::move(sm);
-  return llvm::PreservedAnalyses::none();
+  // The instrumentation invalidates everything else, but not DsaInfoAnalysis:
+  // its result owns the GlobalAnalysis that the ShadowMem we just handed to
+  // *m_keep holds by reference, so invalidating it would leave that reference
+  // (and ShadowMem::getDsaAnalysis) dangling. Keeping it also matches the
+  // legacy pass manager, where the DsaAnalysis pass outlives the
+  // instrumentation and consumers see the same pre-instrumentation graphs.
+  auto PA = llvm::PreservedAnalyses::none();
+  PA.preserve<DsaInfoAnalysis>();
+  return PA;
 }
 
 llvm::PreservedAnalyses


### PR DESCRIPTION
**Required to enable clam in seahorn. Needed by https://github.com/seahorn/seahorn/pull/596**
**It will need to be ported to `dev17` and `dev18`**

ShadowMemNewPmPass returned PreservedAnalyses::none(). DsaInfoAnalysis::Result owns the GlobalAnalysis by unique_ptr and its invalidate() returns true unless preserved, so the module analysis manager destroyed that result as soon as the pass returned. The ShadowMem the pass had just moved into *m_keep holds the GlobalAnalysis by reference, so any consumer of the sink was left with a dangling reference and ShadowMem::getDsaAnalysis() returned freed memory.

Preserve DsaInfoAnalysis instead. This also matches the legacy pass manager, where the DsaAnalysis pass outlives the instrumentation and consumers keep seeing the same pre-instrumentation graphs rather than a recompute over the already-instrumented module.

Why this was latent until Clam/crab was enabled
-----------------------------------------------

The bug is only observable through the `keep` sink, and nothing exercised it:

  * The sink parameter defaults to nullptr and has no in-tree caller, so ShadowMemNewPmPass normally destroys its ShadowMem when it returns and the reference is never read after invalidation.
  * The only consumer that needs the object to outlive the pass is SeaHorn's Bv2OpSem::initCrabAnalysis, which calls getDsaAnalysis() to build clam's SeaDsaHeapAbstraction. That code sits behind #ifdef HAVE_CLAM, and SeaHorn's dev16 built with WITH_CLAM=OFF, so it was compiled out entirely.
  * Every other consumer in the BMC pipeline reads the instrumentation *output* -- the shadow.mem calls left in the IR -- not the ShadowMem object, so the lifetime of the analysis result never mattered to them.

Enabling WITH_CLAM=ON and wiring the sink through to the operational semantics made SeaHorn the first real user of getDsaAnalysis() after the pass, which is when this surfaced: it crashed test/crab (crab_is_deref_{1,2}, crab_rng_1) inside SeaDsaHeapAbstractionImpl::computeReadModNewNodes.

Note for anyone tempted by a smaller fix: re-requesting DsaInfoAnalysis from the MAM at the point of use appears to work, because the freed block is reused and the recomputed result often lands at the same address. It is undefined behaviour and the tests flip between runs.