### PR TITLE
Add opt-in scoped statistics (SEADSA_STATS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 
 option (BUILD_SEA_DSA_LIBS_SHARED "Build all sea-dsa libraries shared." OFF)
 option (ENABLE_SANITY_CHECKS "Enable sea-dsa sanity checks." OFF)
+option (SEADSA_STATS "Enable SeaDsa scoped statistics (SEADSA_SCOPED_STATS macros)." OFF)
 
 if (ENABLE_SANITY_CHECKS)
   message (STATUS "Compiling sea-dsa with sanity checks")
@@ -167,11 +168,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 endif ()
 
 configure_file(include/seadsa/config.h.cmake
-  ${CMAKE_BINARY_DIR}/include/seadsa/config.h)
+  ${CMAKE_CURRENT_BINARY_DIR}/include/seadsa/config.h)
 
 include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_BINARY_DIR}/include)
+  ${CMAKE_CURRENT_BINARY_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_subdirectory(lib/seadsa)
 add_subdirectory(units)

--- a/include/seadsa/config.h.cmake
+++ b/include/seadsa/config.h.cmake
@@ -4,4 +4,7 @@
 /* Define whether sanity checks are enabled */
 #cmakedefine SANITY_CHECKS ${SANITY_CHECKS}
 
+/* Define whether scoped stats support (SEADSA_SCOPED_STATS macros) is enabled */
+#cmakedefine SEADSA_STATS ${SEADSA_STATS}
+
 #endif

--- a/include/seadsa/support/Stats.hh
+++ b/include/seadsa/support/Stats.hh
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "seadsa/config.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+namespace seadsa {
+
+/// Runtime toggle. Statistics are collected only when the library is
+/// compiled with -DSEADSA_STATS=ON *and* this flag is set.
+extern bool SeaDsaStatsFlag;
+void SeaDsaEnableStats(bool v = true);
+
+/// Nested analysis sessions: counters are reset when the outermost
+/// session begins and printed when the outermost session ends.
+void SeaDsaStatsBeginAnalysis();
+void SeaDsaStatsEndAnalysis(llvm::raw_ostream &out = llvm::errs());
+
+class SeaDsaStats {
+public:
+  static void reset();
+  static void count(const std::string &name);
+  static void start(const std::string &name);
+  static void stop(const std::string &name);
+  static void resume(const std::string &name);
+  static void Print(llvm::raw_ostream &out);
+};
+
+/// Times (and optionally counts) the enclosing scope under \p name.
+/// \p name must outlive the scope (use a string literal). Cheap when
+/// stats are disabled at runtime: no allocation is performed until
+/// the flag is on.
+class ScopedSeaDsaStats {
+  const char *m_name;
+  bool m_active;
+
+public:
+  explicit ScopedSeaDsaStats(const char *name, bool use_count = true);
+  ~ScopedSeaDsaStats();
+};
+
+} // namespace seadsa
+
+#define SEADSA_STATS_JOIN_IMPL(a, b) a##b
+#define SEADSA_STATS_JOIN(a, b) SEADSA_STATS_JOIN_IMPL(a, b)
+
+#ifdef SEADSA_STATS
+#define SEADSA_SCOPED_STATS(name, active) SEADSA_SCOPED_STATS_(name, active)
+#define SEADSA_SCOPED_STATS_(name, active) SEADSA_SCOPED_STATS_##active(name)
+#define SEADSA_SCOPED_STATS_0(name)
+#define SEADSA_SCOPED_STATS_1(name)                                            \
+  seadsa::ScopedSeaDsaStats SEADSA_STATS_JOIN(__seadsa_scoped_stats_,          \
+                                              __LINE__)(name)
+
+#define SEADSA_COUNT_STATS(name, active) SEADSA_COUNT_STATS_(name, active)
+#define SEADSA_COUNT_STATS_(name, active) SEADSA_COUNT_STATS_##active(name)
+#define SEADSA_COUNT_STATS_0(name)
+#define SEADSA_COUNT_STATS_1(name) seadsa::SeaDsaStats::count(name)
+
+#define SEADSA_SCOPED_TIMER_STATS(name, active)                                \
+  SEADSA_SCOPED_TIMER_STATS_(name, active)
+#define SEADSA_SCOPED_TIMER_STATS_(name, active)                               \
+  SEADSA_SCOPED_TIMER_STATS_##active(name)
+#define SEADSA_SCOPED_TIMER_STATS_0(name)
+#define SEADSA_SCOPED_TIMER_STATS_1(name)                                      \
+  seadsa::ScopedSeaDsaStats SEADSA_STATS_JOIN(__seadsa_scoped_stats_,          \
+                                              __LINE__)(name, false)
+#else
+#define SEADSA_SCOPED_STATS(name, active)
+#define SEADSA_COUNT_STATS(name, active)
+#define SEADSA_SCOPED_TIMER_STATS(name, active)
+#endif

--- a/lib/seadsa/CMakeLists.txt
+++ b/lib/seadsa/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_llvm_library (SeaDsaAnalysis DISABLE_LLVM_LINK_LLVM_DYLIB
   Graph.cc
+  Stats.cc
   FieldType.cc
   DsaLocal.cc
   DsaGlobal.cc
@@ -29,3 +30,6 @@ add_llvm_library (SeaDsaAnalysis DISABLE_LLVM_LINK_LLVM_DYLIB
   SeaDsaAliasAnalysis.cc
   DsaLibFuncInfo.cc
   )
+
+target_include_directories(SeaDsaAnalysis BEFORE PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/../../include)

--- a/lib/seadsa/Cloner.cc
+++ b/lib/seadsa/Cloner.cc
@@ -1,6 +1,7 @@
 #include "seadsa/Cloner.hh"
 #include "seadsa/CallSite.hh"
 #include "seadsa/support/Debug.h"
+#include "seadsa/support/Stats.hh"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/CommandLine.h"
 using namespace seadsa;
@@ -39,6 +40,12 @@ Node &Cloner::clone(const Node &n, bool forceAddAlloca,
   // -- don't clone nodes that are already in the graph
   if (n.getGraph() == &m_graph)
     return *const_cast<Node *>(&n);
+
+  // Count-only: clone() recurses through node links, so a scoped timer
+  // with a single name would under-account nested calls. The time is
+  // captured by the callers (bu.resolve_args, td.resolve_args,
+  // graph.import.*.clone).
+  SEADSA_COUNT_STATS("cloner.clone_node", 1);
 
   if (NoAllocSiteOpt)
     onlyAllocSite = nullptr;

--- a/lib/seadsa/DsaBottomUp.cc
+++ b/lib/seadsa/DsaBottomUp.cc
@@ -23,6 +23,7 @@
 #include "seadsa/Local.hh"
 #include "seadsa/config.h"
 #include "seadsa/support/Debug.h"
+#include "seadsa/support/Stats.hh"
 
 using namespace llvm;
 
@@ -59,6 +60,7 @@ static const Value *findUniqueReturnValue(const Function &F) {
 void BottomUpAnalysis::cloneAndResolveArguments(
     const DsaCallSite &CS, Graph &calleeG, Graph &callerG,
     const DsaLibFuncInfo &dsaLibFuncInfo, bool flowSensitiveOpt) {
+  SEADSA_SCOPED_STATS("bu.resolve_args", 1);
   CloningContext context(*CS.getInstruction(), CloningContext::BottomUp);
   auto options = Cloner::BuildOptions(Cloner::StripAllocas);
   Cloner C(callerG, context, options);
@@ -134,6 +136,7 @@ void BottomUpAnalysis::cloneAndResolveArguments(
 }
 
 bool BottomUpAnalysis::runOnModule(Module &M, GraphMap &graphs) {
+  SEADSA_SCOPED_STATS("bu.module", 1);
 
   LOG("dsa-bu", errs() << "Started bottom-up analysis ... \n");
 
@@ -156,9 +159,11 @@ bool BottomUpAnalysis::runOnModule(Module &M, GraphMap &graphs) {
       }
       if (m_dsaLibFuncInfo.hasSpecFunc(*fn)) {
         Function &spec_fn = *m_dsaLibFuncInfo.getSpecFunc(*fn);
+        SEADSA_SCOPED_STATS("bu.local_run", 1);
         la.runOnFunction(spec_fn, *fGraph);
 
       } else {
+        SEADSA_SCOPED_STATS("bu.local_run", 1);
         la.runOnFunction(*fn, *fGraph);
       }
 
@@ -208,7 +213,10 @@ bool BottomUpAnalysis::runOnModule(Module &M, GraphMap &graphs) {
       }
     }
 
-    if (fGraph) fGraph->compress();
+    if (fGraph) {
+      SEADSA_SCOPED_STATS("bu.compress", 1);
+      fGraph->compress();
+    }
   }
 
   if (m_dsaLibFuncInfo.genSpecs()) {

--- a/lib/seadsa/DsaGlobal.cc
+++ b/lib/seadsa/DsaGlobal.cc
@@ -28,6 +28,7 @@
 #include "seadsa/config.h"
 
 #include "seadsa/support/Debug.h"
+#include "seadsa/support/Stats.hh"
 
 #include <queue>
 
@@ -94,6 +95,8 @@ bool ContextInsensitiveGlobalAnalysis::runOnModule(Module &M) {
   LOG("dsa-global",
       errs() << "Started context-insensitive global analysis ... \n");
 
+  SEADSA_SCOPED_STATS("ci.global.module", 1);
+
   // ufo::Stats::resume ("CI-DsaAnalysis");
 
   if (kind() == GlobalAnalysisKind::FLAT_MEMORY)
@@ -126,10 +129,13 @@ bool ContextInsensitiveGlobalAnalysis::runOnModule(Module &M) {
       else
         fGraph.reset(new Graph(m_dl, m_setFactory));
 
-      la.runOnFunction(*spec, *fGraph);
+      { SEADSA_SCOPED_STATS("ci.global.local_run", 1);
+        la.runOnFunction(*spec, *fGraph); }
 
       m_fns.insert(spec);
-      m_graph->import(*fGraph, true);
+
+      { SEADSA_SCOPED_STATS("ci.global.import", 1);
+        m_graph->import(*fGraph, true); }
     }
 
     // --- resolve callsites
@@ -151,12 +157,15 @@ bool ContextInsensitiveGlobalAnalysis::runOnModule(Module &M) {
             call_graph_utils::getDsaCallSite(callRecord, &m_dsaLibFuncInfo);
         if ((!dsaCS.has_value())) { continue; }
         assert(fn == dsaCS.value().getCaller());
-        resolveArguments(dsaCS.value(), *m_graph, m_dsaLibFuncInfo);
+        { SEADSA_SCOPED_STATS("ci.global.resolve_args", 1);
+          resolveArguments(dsaCS.value(), *m_graph, m_dsaLibFuncInfo); }
       }
     }
-    m_graph->compress();
+    { SEADSA_SCOPED_STATS("ci.global.compress", 1);
+      m_graph->compress(); }
   }
-  m_graph->remove_dead();
+  { SEADSA_SCOPED_STATS("ci.global.remove_dead", 1);
+    m_graph->remove_dead(); }
 
   // ufo::Stats::stop ("CI-DsaAnalysis");
 

--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -39,6 +39,7 @@
 #include "seadsa/Graph.hh"
 #include "seadsa/TypeUtils.hh"
 #include "seadsa/support/Debug.h"
+#include "seadsa/support/Stats.hh"
 
 #include "boost/range/algorithm/reverse.hpp"
 
@@ -403,6 +404,7 @@ public:
 };
 
 void InterBlockBuilder::visitPHINode(PHINode &PHI) {
+  SEADSA_SCOPED_STATS("local.phi", 1);
   if (!PHI.getType()->isPointerTy()) return;
 
   assert(m_graph.hasCell(PHI));
@@ -656,6 +658,7 @@ seadsa::Cell BlockBuilderBase::valueCell(const Value &v) {
 }
 
 void IntraBlockBuilder::visitInstruction(Instruction &I) {
+  SEADSA_SCOPED_STATS("local.inst", 1);
   if (isSkip(I)) return;
 
   m_graph.mkCell(I, seadsa::Cell(m_graph.mkNode(), 0));
@@ -677,6 +680,7 @@ void IntraBlockBuilder::visitAllocaInst(AllocaInst &AI) {
 
 void IntraBlockBuilder::visitSelectInst(SelectInst &SI) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.sel", 1);
   if (isSkip(SI)) return;
 
   assert(!m_graph.hasCell(SI));
@@ -691,6 +695,7 @@ void IntraBlockBuilder::visitSelectInst(SelectInst &SI) {
 
 void IntraBlockBuilder::visitLoadInst(LoadInst &LI) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.load", 1);
 
   // -- skip read from NULL
   if (BlockBuilderBase::isNullConstant(*LI.getPointerOperand())) return;
@@ -759,6 +764,7 @@ void IntraBlockBuilder::visitLoadInst(LoadInst &LI) {
 /// return {OldVal, Success}
 void IntraBlockBuilder::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.cmpxchg", 1);
 
   if (!m_graph.hasCell(*I.getPointerOperand()->stripPointerCasts())) { return; }
   Value *Ptr = I.getPointerOperand();
@@ -798,6 +804,7 @@ void IntraBlockBuilder::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
 /// *Ptr = op(OldVal, Val)
 /// return OldVal
 void IntraBlockBuilder::visitAtomicRMWInst(AtomicRMWInst &I) {
+  SEADSA_SCOPED_STATS("local.rmw", 1);
   Value *Ptr = I.getPointerOperand();
 
   seadsa::Cell PtrC = valueCell(*Ptr);
@@ -817,6 +824,10 @@ void IntraBlockBuilder::visitAtomicRMWInst(AtomicRMWInst &I) {
 
 void IntraBlockBuilder::visitStoreInst(StoreInst &SI) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.store", 1);
+  LOG("dsa-store", errs() << "before: \n";
+      // m_graph.write(llvm::errs());
+      errs() << "Visiting STORE: " << SI << "\n";);
 
   // -- skip store into NULL
   if (BlockBuilderBase::isNullConstant(
@@ -870,6 +881,7 @@ void IntraBlockBuilder::visitStoreInst(StoreInst &SI) {
 }
 
 void IntraBlockBuilder::visitBitCastInst(BitCastInst &I) {
+  SEADSA_SCOPED_STATS("local.bitcast", 1);
   if (isSkip(I)) return;
 
   if (BlockBuilderBase::isNullConstant(*I.getOperand(0)))
@@ -1078,6 +1090,7 @@ void BlockBuilderBase::visitGep(const Value &gep, const Value &ptr,
 }
 
 void IntraBlockBuilder::visitGetElementPtrInst(GetElementPtrInst &I) {
+  SEADSA_SCOPED_STATS("local.gep", 1);
   Value &ptr = *I.getPointerOperand();
 
   if (isa<ConstantExpr>(ptr)) {
@@ -1107,6 +1120,7 @@ void IntraBlockBuilder::visitGetElementPtrInst(GetElementPtrInst &I) {
 }
 
 void IntraBlockBuilder::visitInsertValueInst(InsertValueInst &I) {
+  SEADSA_SCOPED_STATS("local.insv", 1);
   assert(I.getAggregateOperand()->getType() == I.getType());
   using namespace seadsa;
 
@@ -1146,6 +1160,7 @@ void IntraBlockBuilder::visitInsertValueInst(InsertValueInst &I) {
 
 void IntraBlockBuilder::visitExtractValueInst(ExtractValueInst &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.extv", 1);
   Cell op = valueCell(*I.getAggregateOperand()->stripPointerCasts());
   if (op.isNull()) {
     Node &n = m_graph.mkNode();
@@ -1188,6 +1203,7 @@ void IntraBlockBuilder::visitExtractValueInst(ExtractValueInst &I) {
 
 void IntraBlockBuilder::visitInlineAsmCall(CallBase &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.asm", 1);
   assert(I.isInlineAsm());
 
   if (isSkip(I)) return;
@@ -1202,6 +1218,7 @@ void IntraBlockBuilder::visitInlineAsmCall(CallBase &I) {
 
 void IntraBlockBuilder::visitExternalCall(CallBase &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.ext", 1);
   if (isSkip(I)) return;
 
   auto *callee = getCalledFunction(I);
@@ -1243,6 +1260,7 @@ void IntraBlockBuilder::visitExternalCall(CallBase &I) {
 
 void IntraBlockBuilder::visitIndirectCall(CallBase &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.icall", 1);
   if (!isSkip(I)) m_graph.mkCell(I, Cell(m_graph.mkNode(), 0));
 
   if (!m_track_callsites) return;
@@ -1261,6 +1279,7 @@ void IntraBlockBuilder::visitIndirectCall(CallBase &I) {
 void IntraBlockBuilder::visitSeaDsaFnCall(CallBase &I) {
   using namespace llvm::PatternMatch;
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.dsa_fn", 1);
   auto *callee = getCalledFunction(I);
   SeadsaFn fn = getSeaDsaFn(callee);
 
@@ -1449,11 +1468,13 @@ void IntraBlockBuilder::visitSeaDsaFnCall(CallBase &I) {
 }
 
 void IntraBlockBuilder::visitAllocWrapperCall(CallBase &I) {
+  SEADSA_SCOPED_STATS("local.awrap", 1);
   visitAllocationFnCall(I);
 }
 
 void IntraBlockBuilder::visitAllocationFnCall(CallBase &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.alloca", 1);
   Node &n = m_graph.mkNode();
   // -- record allocation site
   seadsa::DsaAllocSite *site = m_graph.mkAllocSite(I);
@@ -1467,6 +1488,7 @@ void IntraBlockBuilder::visitAllocationFnCall(CallBase &I) {
 
 void IntraBlockBuilder::visitCallBase(CallBase &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.call", 1);
 
   if (I.isInlineAsm()) {
     visitInlineAsmCall(I);
@@ -1518,6 +1540,7 @@ void IntraBlockBuilder::visitCallBase(CallBase &I) {
 
 void IntraBlockBuilder::visitShuffleVectorInst(ShuffleVectorInst &I) {
   using namespace seadsa;
+  SEADSA_SCOPED_STATS("local.shuf", 1);
 
   // XXX: TODO: handle properly.
   LOG("dsa-warn",
@@ -1527,6 +1550,7 @@ void IntraBlockBuilder::visitShuffleVectorInst(ShuffleVectorInst &I) {
 }
 
 void IntraBlockBuilder::visitMemSetInst(MemSetInst &I) {
+  SEADSA_SCOPED_STATS("local.mset", 1);
   seadsa::Cell dest = valueCell(*(I.getDest()));
   // assert (!dest.isNull ());
   if (!dest.isNull()) dest.setModified();
@@ -1607,6 +1631,7 @@ bool transfersNoPointers(MemTransferInst &MI, const DataLayout &DL) {
 }
 
 void IntraBlockBuilder::visitMemTransferInst(MemTransferInst &I) {
+  SEADSA_SCOPED_STATS("local.memtrans", 1);
   // -- skip copy NULL
   if (isNullConstant(*I.getSource())) return;
 
@@ -1726,6 +1751,7 @@ bool BlockBuilderBase::isFixedOffset(const IntToPtrInst &inst, Value *&base,
 }
 
 void BlockBuilderBase::visitCastIntToPtr(const Value &dest) {
+  SEADSA_SCOPED_STATS("local.i2p.cast", 1);
   // -- only used as a compare. do not needs DSA node
   // if (dest.hasOneUse () && isa<CmpInst> (*(dest.use_begin ()))) return;
   // XXX: we create a new cell for the instruction even if
@@ -1772,10 +1798,12 @@ void BlockBuilderBase::visitCastIntToPtr(const Value &dest) {
 }
 
 void IntraBlockBuilder::visitIntToPtrInst(IntToPtrInst &I) {
+  SEADSA_SCOPED_STATS("local.i2p", 1);
   visitCastIntToPtr(I);
 }
 
 void IntraBlockBuilder::visitReturnInst(ReturnInst &RI) {
+  SEADSA_SCOPED_STATS("local.ret", 1);
   Value *v = RI.getReturnValue();
 
   // We don't skip the return value if its type contains a pointer.
@@ -1843,6 +1871,7 @@ bool isEscapingPtrToInt(const PtrToIntInst &def) {
 }
 
 void IntraBlockBuilder::visitPtrToIntInst(PtrToIntInst &I) {
+  SEADSA_SCOPED_STATS("local.p2i", 1);
   if (!isEscapingPtrToInt(I)) return;
 
   if (BlockBuilderBase::isNullConstant(*I.getOperand(0))) return;
@@ -1886,6 +1915,7 @@ namespace seadsa {
 void LocalAnalysis::runOnFunction(Function &F, Graph &g) {
   LOG("dsa-progress",
       errs() << "Running seadsa::Local on " << F.getName() << "\n");
+  SEADSA_SCOPED_STATS("local.function", 1);
 
   auto &tli = m_getTLI(F);
   // create cells and nodes for formal arguments

--- a/lib/seadsa/DsaTopDown.cc
+++ b/lib/seadsa/DsaTopDown.cc
@@ -20,6 +20,7 @@
 #include "seadsa/Local.hh"
 #include "seadsa/config.h"
 #include "seadsa/support/Debug.h"
+#include "seadsa/support/Stats.hh"
 
 using namespace llvm;
 
@@ -42,6 +43,7 @@ void TopDownAnalysis::cloneAndResolveArguments(const DsaCallSite &cs,
                                                Graph &callerG, Graph &calleeG,
                                                bool flowSensitiveOpt,
                                                bool noescape) {
+  SEADSA_SCOPED_STATS("td.resolve_args", 1);
   CloningContext context(*cs.getInstruction(), CloningContext::TopDown);
   auto options = Cloner::BuildOptions(Cloner::StripAllocas);
   Cloner C(calleeG, context, options);
@@ -115,6 +117,7 @@ void TopDownAnalysis::cloneAndResolveArguments(const DsaCallSite &cs,
 }
 
 void TopDownAnalysis::removeForeignNodes(Graph &graph) {
+  SEADSA_SCOPED_STATS("td.remove_foreign", 1);
   if (!NoTDCopyingOpt) {
     graph.compress();
     graph.removeNodes([](const Node *n) { return n->isForeign(); });
@@ -122,6 +125,7 @@ void TopDownAnalysis::removeForeignNodes(Graph &graph) {
 }
 
 bool TopDownAnalysis::runOnModule(Module &M, GraphMap &graphs) {
+  SEADSA_SCOPED_STATS("td.module", 1);
   LOG("dsa-td", errs() << "Started top-down analysis ... \n");
 
   // The SCC iterator has the property that the graph is traversed in

--- a/lib/seadsa/Graph.cc
+++ b/lib/seadsa/Graph.cc
@@ -16,6 +16,7 @@
 #include "seadsa/Graph.hh"
 #include "seadsa/Mapper.hh"
 #include "seadsa/support/Debug.h"
+#include "seadsa/support/Stats.hh"
 
 #include "boost/range/algorithm/set_algorithm.hpp"
 #include "boost/range/iterator_range.hpp"
@@ -1335,35 +1336,71 @@ void Graph::import(const Graph &g, bool withFormals) {
   Cloner C(*this, CloningContext::mkNoContext(), Cloner::Options::Basic);
   for (auto &kv : g.m_values) {
     // -- clone node
-    Node &n = C.clone(*kv.second->getNode());
+    Node *n = nullptr;
+    {
+      SEADSA_SCOPED_STATS("graph.import.values.clone", 1);
+      n = &C.clone(*kv.second->getNode());
+    }
 
     // -- re-create the cell
-    Cell c(n, kv.second->getRawOffset());
+    Cell c(*n, kv.second->getRawOffset());
 
     // -- insert value
-    Cell &nc = mkCell(*kv.first, Cell());
+    Cell *nc = nullptr;
+    {
+      SEADSA_SCOPED_STATS("graph.import.values.mkcell", 1);
+      nc = &mkCell(*kv.first, Cell());
+    }
 
     // -- unify the old and new cells
-    nc.unify(c);
+    {
+      SEADSA_SCOPED_STATS("graph.import.values.unify", 1);
+      nc->unify(c);
+    }
   }
 
   if (withFormals) {
     for (auto &kv : g.m_formals) {
-      Node &n = C.clone(*kv.second->getNode());
-      Cell c(n, kv.second->getRawOffset());
-      Cell &nc = mkCell(*kv.first, Cell());
-      nc.unify(c);
+      Node *n = nullptr;
+      {
+        SEADSA_SCOPED_STATS("graph.import.formals.clone", 1);
+        n = &C.clone(*kv.second->getNode());
+      }
+      Cell c(*n, kv.second->getRawOffset());
+      Cell *nc = nullptr;
+      {
+        SEADSA_SCOPED_STATS("graph.import.formals.mkcell", 1);
+        nc = &mkCell(*kv.first, Cell());
+      }
+      {
+        SEADSA_SCOPED_STATS("graph.import.formals.unify", 1);
+        nc->unify(c);
+      }
     }
     for (auto &kv : g.m_returns) {
-      Node &n = C.clone(*kv.second->getNode());
-      Cell c(n, kv.second->getRawOffset());
-      Cell &nc = mkRetCell(*kv.first, Cell());
-      nc.unify(c);
+      Node *n = nullptr;
+      {
+        SEADSA_SCOPED_STATS("graph.import.returns.clone", 1);
+        n = &C.clone(*kv.second->getNode());
+      }
+      Cell c(*n, kv.second->getRawOffset());
+      Cell *nc = nullptr;
+      {
+        SEADSA_SCOPED_STATS("graph.import.returns.mkretcell", 1);
+        nc = &mkRetCell(*kv.first, Cell());
+      }
+      {
+        SEADSA_SCOPED_STATS("graph.import.returns.unify", 1);
+        nc->unify(c);
+      }
     }
   }
 
   // possibly created many indirect links, compress
-  compress();
+  {
+    SEADSA_SCOPED_STATS("graph.import.compress", 1);
+    compress();
+  }
 }
 
 void Graph::write(raw_ostream &o) const {

--- a/lib/seadsa/Stats.cc
+++ b/lib/seadsa/Stats.cc
@@ -1,0 +1,307 @@
+#include "seadsa/support/Stats.hh"
+
+#include "seadsa/config.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace seadsa {
+
+bool SeaDsaStatsFlag = false;
+static unsigned SeaDsaStatsActiveAnalyses = 0;
+void SeaDsaEnableStats(bool v) { SeaDsaStatsFlag = v; }
+
+void SeaDsaStatsBeginAnalysis() {
+  if (!SeaDsaStatsFlag) {
+    return;
+  }
+
+  if (SeaDsaStatsActiveAnalyses == 0) {
+    SeaDsaStats::reset();
+  }
+  ++SeaDsaStatsActiveAnalyses;
+}
+
+void SeaDsaStatsEndAnalysis(llvm::raw_ostream &out) {
+  if (!SeaDsaStatsFlag || SeaDsaStatsActiveAnalyses == 0) {
+    return;
+  }
+
+  --SeaDsaStatsActiveAnalyses;
+  if (SeaDsaStatsActiveAnalyses == 0) {
+    SeaDsaStats::Print(out);
+  }
+}
+
+#ifndef SEADSA_STATS
+
+void SeaDsaStats::reset() {}
+
+void SeaDsaStats::count(const std::string &name) { (void)name; }
+
+void SeaDsaStats::start(const std::string &name) { (void)name; }
+
+void SeaDsaStats::stop(const std::string &name) { (void)name; }
+
+void SeaDsaStats::resume(const std::string &name) { (void)name; }
+
+void SeaDsaStats::Print(llvm::raw_ostream &o) {
+  o << "\n\n************** STATS ***************** \n";
+  o << "SeaDsa compiled without support for scoped stats "
+       "(SEADSA_SCOPED_STATS). "
+       "Compile SeaDsa with -DSEADSA_STATS=ON\n";
+  o << "************** STATS END ***************** \n";
+}
+
+ScopedSeaDsaStats::ScopedSeaDsaStats(const char *name, bool use_count)
+    : m_name(name), m_active(false) {
+  (void)use_count;
+}
+
+ScopedSeaDsaStats::~ScopedSeaDsaStats() {}
+
+#else
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+struct Stopwatch {
+  Clock::time_point started = Clock::time_point();
+  Clock::time_point finished = Clock::time_point();
+  std::chrono::nanoseconds elapsed = std::chrono::nanoseconds::zero();
+
+  void start() {
+    started = Clock::now();
+    finished = Clock::time_point();
+    elapsed = std::chrono::nanoseconds::zero();
+  }
+
+  void resume() {
+    if (finished != Clock::time_point()) {
+      elapsed += std::chrono::duration_cast<std::chrono::nanoseconds>(
+          finished - started);
+      started = Clock::now();
+      finished = Clock::time_point();
+    } else if (started == Clock::time_point()) {
+      started = Clock::now();
+    }
+  }
+
+  void stop() {
+    if (started != Clock::time_point() && finished == Clock::time_point()) {
+      finished = Clock::now();
+    }
+  }
+
+  std::chrono::nanoseconds total() const {
+    if (started == Clock::time_point()) {
+      return elapsed;
+    }
+    if (finished == Clock::time_point()) {
+      return elapsed + std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           Clock::now() - started);
+    }
+    return elapsed + std::chrono::duration_cast<std::chrono::nanoseconds>(
+                         finished - started);
+  }
+};
+
+std::unordered_map<std::string, unsigned> &getCounters() {
+  static std::unordered_map<std::string, unsigned> counters;
+  return counters;
+}
+
+std::unordered_map<std::string, Stopwatch> &getTimers() {
+  static std::unordered_map<std::string, Stopwatch> timers;
+  return timers;
+}
+
+std::string formatElapsedTime(std::chrono::nanoseconds elapsed) {
+  using namespace std::chrono;
+
+  const auto ns = elapsed.count();
+  std::ostringstream os;
+
+  if (ns >= 1000000000LL) {
+    const double secs = duration<double>(elapsed).count();
+    os << std::fixed << std::setprecision(2) << secs << " s";
+  } else if (ns >= 1000000LL) {
+    const double ms = duration<double, std::milli>(elapsed).count();
+    os << std::fixed << std::setprecision(2) << ms << " ms";
+  } else if (ns >= 1000LL) {
+    const double us = duration<double, std::micro>(elapsed).count();
+    os << std::fixed << std::setprecision(0) << us << " us";
+  } else {
+    os << ns << " ns";
+  }
+
+  return os.str();
+}
+
+} // namespace
+
+void SeaDsaStats::reset() {
+  if (SeaDsaStatsFlag) {
+    getCounters().clear();
+    getTimers().clear();
+  }
+}
+
+void SeaDsaStats::count(const std::string &name) {
+  if (SeaDsaStatsFlag) {
+    ++getCounters()[name];
+  }
+}
+
+void SeaDsaStats::start(const std::string &name) {
+  if (SeaDsaStatsFlag) {
+    getTimers()[name].start();
+  }
+}
+
+void SeaDsaStats::stop(const std::string &name) {
+  if (SeaDsaStatsFlag) {
+    getTimers()[name].stop();
+  }
+}
+
+void SeaDsaStats::resume(const std::string &name) {
+  if (SeaDsaStatsFlag) {
+    getTimers()[name].resume();
+  }
+}
+
+void SeaDsaStats::Print(llvm::raw_ostream &o) {
+  if (!SeaDsaStatsFlag) {
+    o << "\n\n************** STATS ***************** \n";
+    o << "Need to call SeaDsaEnableStats()\n";
+    o << "************** STATS END ***************** \n";
+    return;
+  }
+
+  struct StatsRow {
+    std::string name;
+    unsigned count = 0;
+    std::string time;
+  };
+
+  std::vector<StatsRow> rows;
+  rows.reserve(std::max(getCounters().size(), getTimers().size()));
+
+  std::unordered_map<std::string, std::size_t> row_index;
+  row_index.reserve(getCounters().size() + getTimers().size());
+
+  for (const auto &kv : getCounters()) {
+    auto it = row_index.find(kv.first);
+    if (it == row_index.end()) {
+      row_index.emplace(kv.first, rows.size());
+      rows.push_back({kv.first, kv.second, "-"});
+    } else {
+      rows[it->second].count = kv.second;
+    }
+  }
+
+  for (const auto &kv : getTimers()) {
+    const auto total = kv.second.total();
+    const std::string pretty_time = formatElapsedTime(total);
+
+    auto it = row_index.find(kv.first);
+    if (it == row_index.end()) {
+      row_index.emplace(kv.first, rows.size());
+      rows.push_back({kv.first, 0, pretty_time});
+    } else {
+      rows[it->second].time = pretty_time;
+    }
+  }
+
+  std::sort(rows.begin(), rows.end(),
+            [](const StatsRow &a, const StatsRow &b) {
+              return a.name < b.name;
+            });
+
+  const std::string function_header = "function";
+  const std::string called_header = "called";
+  const std::string time_header = "time";
+
+  std::size_t function_width = function_header.size();
+  std::size_t called_width = called_header.size();
+  std::size_t time_width = time_header.size();
+
+  for (const auto &row : rows) {
+    function_width = std::max(function_width, row.name.size());
+    const auto count_width = std::to_string(row.count).size();
+    called_width = std::max(called_width, count_width);
+    time_width = std::max(time_width, row.time.size());
+  }
+
+  const auto printSeparator = [&](char ch) {
+    o << "+" << std::string(function_width + 2, ch) << "+"
+      << std::string(called_width + 2, ch) << "+"
+      << std::string(time_width + 2, ch) << "+\n";
+  };
+
+  const auto printCell = [&](const std::string &text, std::size_t width,
+                             bool right_align = false) {
+    o << " ";
+    const std::size_t pad = (width > text.size()) ? (width - text.size()) : 0;
+    if (right_align) {
+      o << std::string(pad, ' ') << text;
+    } else {
+      o << text << std::string(pad, ' ');
+    }
+    o << " ";
+  };
+
+  o << "\n\n************** STATS ***************** \n";
+  printSeparator('-');
+  o << "|";
+  printCell(function_header, function_width);
+  o << "|";
+  printCell(called_header, called_width, true);
+  o << "|";
+  printCell(time_header, time_width, true);
+  o << "|\n";
+  printSeparator('=');
+
+  for (const auto &row : rows) {
+    o << "|";
+    printCell(row.name, function_width);
+    o << "|";
+    printCell(std::to_string(row.count), called_width, true);
+    o << "|";
+    printCell(row.time, time_width, true);
+    o << "|\n";
+  }
+
+  printSeparator('-');
+  o << "************** STATS END ***************** \n";
+}
+
+ScopedSeaDsaStats::ScopedSeaDsaStats(const char *name, bool use_count)
+    : m_name(name), m_active(SeaDsaStatsFlag) {
+  if (!m_active) {
+    return;
+  }
+  SeaDsaStats::resume(m_name);
+  if (use_count) {
+    SeaDsaStats::count(m_name);
+  }
+}
+
+ScopedSeaDsaStats::~ScopedSeaDsaStats() {
+  if (m_active) {
+    SeaDsaStats::stop(m_name);
+  }
+}
+
+#endif
+
+} // namespace seadsa

--- a/tools/seadsa.cc
+++ b/tools/seadsa.cc
@@ -34,6 +34,7 @@
 #include "seadsa/ShadowMem.hh"
 #include "seadsa/support/Debug.h"
 #include "seadsa/support/RemovePtrToInt.hh"
+#include "seadsa/support/Stats.hh"
 
 static llvm::cl::opt<std::string>
     InputFilename(llvm::cl::Positional,
@@ -66,6 +67,12 @@ static llvm::cl::opt<bool> MemViewer(
 static llvm::cl::opt<bool> CallGraphDot(
     "sea-dsa-callgraph-dot",
     llvm::cl::desc("Print SeaDsa complete call graph to dot format"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> ScopedStats(
+    "sea-dsa-scoped-stats",
+    llvm::cl::desc(
+        "Print scoped statistics (requires a -DSEADSA_STATS=ON build)"),
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool> RunShadowMem("sea-dsa-shadow-mem",
@@ -239,6 +246,11 @@ int main(int argc, char **argv) {
   if (!AsmOutputFilename.empty())
     pass_manager.add(createPrintModulePass(asmOutput->os()));
 
+  if (ScopedStats) {
+    seadsa::SeaDsaEnableStats();
+    seadsa::SeaDsaStatsBeginAnalysis();
+  }
+
   pass_manager.run(*module.get());
 
   if (AAEval && !RunShadowMem) {
@@ -272,6 +284,8 @@ int main(int argc, char **argv) {
     MPM.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::AAEvaluator()));
     MPM.run(*module, MAM);
   }
+
+  if (ScopedStats) { seadsa::SeaDsaStatsEndAnalysis(llvm::errs()); }
 
   if (!AsmOutputFilename.empty()) asmOutput->keep();
 

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(units_sea_dsa EXCLUDE_FROM_ALL
     units_sea_dsa.cpp
     FieldTypeTests.cpp
     ShadowMemNewPmTests.cpp
+    StatsTests.cpp
   )
 llvm_config (units_sea_dsa ${LLVM_LINK_COMPONENTS})
 

--- a/units/StatsTests.cpp
+++ b/units/StatsTests.cpp
@@ -1,0 +1,45 @@
+#include "doctest.h"
+
+#include "seadsa/support/Stats.hh"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+TEST_CASE("seadsa.stats.api") {
+  // The API must be safe to call regardless of whether the library was
+  // compiled with SEADSA_STATS.
+  seadsa::SeaDsaEnableStats(true);
+  seadsa::SeaDsaStatsBeginAnalysis();
+  {
+    SEADSA_SCOPED_STATS("units.stats.scope", 1);
+    seadsa::SeaDsaStats::count("units.stats.counter");
+  }
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  seadsa::SeaDsaStatsEndAnalysis(os);
+  os.flush();
+
+#ifdef SEADSA_STATS
+  CHECK(out.find("units.stats.scope") != std::string::npos);
+  CHECK(out.find("units.stats.counter") != std::string::npos);
+#else
+  // Stub build: the printer emits a banner explaining how to enable stats.
+  CHECK(out.find("SEADSA_SCOPED_STATS") != std::string::npos);
+#endif
+  seadsa::SeaDsaEnableStats(false);
+}
+
+TEST_CASE("seadsa.stats.disabled_at_runtime") {
+  // With the runtime flag off, sessions are no-ops and print nothing.
+  seadsa::SeaDsaEnableStats(false);
+  seadsa::SeaDsaStatsBeginAnalysis();
+  {
+    SEADSA_SCOPED_STATS("units.stats.unused", 1);
+  }
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  seadsa::SeaDsaStatsEndAnalysis(os);
+  os.flush();
+  CHECK(out.empty());
+}


### PR DESCRIPTION
This PR adds a lightweight, opt-in statistics facility for profiling where
sea-dsa spends its time, useful when analyzing large modules where the DSA
phase cost is hard to attribute (local vs bottom-up vs top-down vs graph
import).

### Design

Two gates keep it zero-cost by default:

- **Compile time**: a new CMake option `SEADSA_STATS` (default `OFF`). When
  off, the `SEADSA_SCOPED_STATS` / `SEADSA_COUNT_STATS` /
  `SEADSA_SCOPED_TIMER_STATS` macros compile to nothing, so instrumented
  code is byte-identical to today's.
- **Runtime**: `seadsa::SeaDsaEnableStats()`. In a stats-enabled build with
  the flag off, each scope costs a pointer store and a bool check — no
  allocation, no map access.

Each named scope records both a call count and accumulated wall-clock time
(single-name variants exist for count-only and time-only). Sessions are
refcounted (`SeaDsaStatsBeginAnalysis` / `SeaDsaStatsEndAnalysis`) so an
embedding client running nested analyses resets once and prints once.

### What is instrumented

- `local.*` — every instruction visitor of the local analysis, plus a
  per-function scope
- `ci.global.*` — context-insensitive global analysis phases (local run,
  import, argument resolution, compression, dead-node removal)
- `bu.*` / `td.*` — bottom-up and top-down phases (module, per-function
  local run, per-callsite argument resolution, compression / foreign-node
  removal)
- `graph.import.*` — the clone/mkcell/unify/compress steps of
  `Graph::import`
- `cloner.clone_node` — count-only (`Cloner::clone` recurses through node
  links, so a single-name self-timer would under-account; its time is
  attributed to the calling scopes)

### Usage
```sh
    seadsa --sea-dsa=butd-cs --sea-dsa-scoped-stats file.ll
```

(named `--sea-dsa-scoped-stats` to avoid clashing with the existing
`--sea-dsa-stats` graph-statistics pass) prints on exit:

    ************** STATS *****************
    +-------------------+--------+--------+
    | function          | called |   time |
    +===================+========+========+
    | bu.local_run      |      3 |  29 us |
    | bu.module         |      1 |  43 us |
    | bu.resolve_args   |      2 |   8 us |
    | cloner.clone_node |      4 |      - |
    | td.module         |      1 |  15 us |
    ...

Also included: `config.h` is now configured into `CMAKE_CURRENT_BINARY_DIR`
and the binary include dir is preferred, so embedded builds (e.g. clam)
cannot pick up a stale `config.h` from another build tree.

### Testing

- Unit tests (`units/StatsTests.cpp`) cover both build configurations:
  with `SEADSA_STATS=ON`, recorded scopes and counters appear in the
  printed table; with `OFF`, the stub banner; runtime-disabled sessions
  print nothing.
- Built and unit-tested in both configurations with clang-14 / LLVM 14.

A forward-port to `dev18` is prepared and will follow once this lands.
