### PR TITLE
Interval-offset cells: field-sensitivity-preserving partial collapse (I-DSA)

### DIFF
--- a/include/seadsa/Graph.hh
+++ b/include/seadsa/Graph.hh
@@ -5,6 +5,7 @@
 #include "boost/functional/hash.hpp"
 #include "boost/iterator/filter_iterator.hpp"
 #include "boost/iterator/indirect_iterator.hpp"
+#include "boost/optional/optional.hpp"
 
 // llvm 3.8: forward declarations not enough
 #include "llvm/IR/Argument.h"
@@ -37,8 +38,16 @@ using CellRef = std::unique_ptr<Cell>;
 class DsaCallSite;
 class DsaAllocator;
 extern bool g_IsTypeAware;
+/// Global flag controlling whether DSA uses partial offset collapse
+extern bool g_IsPartialCollapseEnabled;
 
-// Data structure graph traversal iterator
+/// True iff partial (interval) collapse is enabled AND usable: interval
+/// cells key fields at type granularity, so the feature relies on
+/// --sea-dsa-type-aware. If --sea-dsa-partial-collapse is set without it,
+/// this warns once and reports false (partial collapse stays off).
+bool IsPartialCollapseActive();
+
+/// Data structure graph traversal iterator
 template <typename T> class NodeIterator;
 
 struct DsaAllocatorDeleter {
@@ -84,12 +93,13 @@ protected:
   using ValueToAllocSite = llvm::DenseMap<const llvm::Value *, DsaAllocSite *>;
   ValueToAllocSite m_valueToAllocSite;
 
-  /// Indirect call sites owned by this graph
+  using CallSites =
+      std::vector<std::unique_ptr<DsaCallSite>>; /// Indirect call sites owned
+                                                 /// by this graph
   ///
   /// The call site can be defined in the current function or any
   /// direct or indirect callee. Call sites are copied from callees to
   /// callers during bottom-up propagation.
-  using CallSites = std::vector<std::unique_ptr<DsaCallSite>>;
   CallSites m_callSites;
 
   /// Map from instructions to call sites
@@ -284,8 +294,14 @@ public:
 };
 
 /**
- *  Graph with one single node
- **/
+ * @class FlatGraph
+ * @brief A graph with a single collapsed node (field-insensitive)
+ *
+ * FlatGraph represents the most conservative DSA analysis where all
+ * memory is collapsed into a single node. This loses all field sensitivity
+ * but is sound and fast. Useful for baseline comparisons or when precision
+ * is not required.
+ */
 class FlatGraph : public Graph {
 
 public:
@@ -334,28 +350,72 @@ public:
 };
 
 /**
-    A memory cell (or a field). An offset into a memory object.
-*/
+ * @class Cell
+ * @brief A memory cell representing an interval into a DSA node
+ *
+ * A Cell is essentially a triple (Node*, start, end) that references a
+ * location or an interval within a memory object. A singleton cell at offset
+ * N is represented as [N, N]. An absent end represents an infinite interval.
+ * Cells are the fundamental unit for tracking data flow and aliasing in DSA.
+ *
+ * Cells can be:
+ * - Null (pointing to no node)
+ * - Direct (pointing to a non-forwarding node)
+ * - Indirect (pointing to a forwarding node, resolved on access)
+ */
 class Cell {
-  /// memory object
-  mutable Node *m_node = nullptr;
-  /// field offset
-  mutable unsigned m_offset = 0;
+protected:
+  mutable Node *m_node =
+      nullptr; ///< The memory object (node) this cell refers to
+  mutable unsigned m_offset =
+      0; ///< Byte offset within the node, start of the interval
+  mutable boost::optional<unsigned> m_end =
+      0; ///< Inclusive interval end, none means infinity
 
-  constexpr std::tuple<Node *, unsigned> asTuple() const {
-    return std::make_tuple(m_node, m_offset);
+  std::tuple<Node *, unsigned, boost::optional<unsigned>> asTuple() const {
+    return std::make_tuple(m_node, m_offset, m_end);
   };
 
 public:
   Cell() = default;
   Cell(const Cell &) = default;
 
-  Cell(Node *node, unsigned offset) : m_node(node), m_offset(offset) {}
-  Cell(Node &node, unsigned offset) : m_node(&node), m_offset(offset) {}
+  /**
+   * @brief Construct a cell pointing to a node at given offset
+   * @param node Pointer to the node
+   * @param offset Byte offset into the node
+   */
+  Cell(Node *node, unsigned offset)
+      : m_node(node), m_offset(offset), m_end(offset) {}
+  Cell(Node *node, unsigned start, boost::optional<unsigned> end)
+      : m_node(node), m_offset(start), m_end(end) {}
+
+  /**
+   * @brief Construct a cell pointing to a node at given offset
+   * @param node Reference to the node
+   * @param offset Byte offset into the node
+   */
+  Cell(Node &node, unsigned offset)
+      : m_node(&node), m_offset(offset), m_end(offset) {}
+  Cell(Node &node, unsigned start, boost::optional<unsigned> end)
+      : m_node(&node), m_offset(start), m_end(end) {}
+
+  /**
+   * @brief Construct a cell from another cell with additional offset
+   * @param o Base cell
+   * @param offset Additional offset to add
+   */
   Cell(const Cell &o, unsigned offset)
-      : m_node(o.m_node), m_offset(o.m_offset + offset) {}
+      : m_node(o.m_node), m_offset(o.m_offset + offset) {
+    if (o.m_end)
+      m_end = o.m_end.get() + offset;
+    else
+      m_end = boost::none;
+  }
 
   Cell &operator=(const Cell &o) = default;
+
+  ~Cell() = default;
 
   bool operator==(const Cell &o) const { return asTuple() == o.asTuple(); }
   bool operator!=(const Cell &o) const { return !operator==(o); }
@@ -374,12 +434,74 @@ public:
   // for Dsa clients (offset is adjusted based on the node)
   unsigned getOffset() const;
 
+  /// @brief Get the raw inclusive interval end, if finite.
+  boost::optional<unsigned> getRawEndOffset() const;
+
+  /// @brief Get the adjusted inclusive interval end, if finite.
+  boost::optional<unsigned> getEndOffset() const;
+
+  /// Compatibility aliases for existing graph clients.
+  unsigned getRawStartOffset() const { return getRawOffset(); }
+  unsigned getStartOffset() const;
+
+  /// @brief True if the interval contains the given offset.
+  bool includes(unsigned o) const {
+    return m_offset <= o && (!m_end || o <= m_end.get());
+  }
+
+  /// @brief True if this interval contains the whole interval of another cell.
+  bool includes(const Cell &o) const {
+    if (m_node != o.m_node || o.m_offset < m_offset) return false;
+    if (!m_end) return true;
+    return o.m_end && o.m_end.get() <= m_end.get();
+  }
+
+  /// @brief True if two interval cells do not overlap.
+  bool isDisjoint(const Cell &o) const {
+    if (m_node != o.m_node) return true;
+    if (!m_end && !o.m_end) return false;
+    if (!m_end) return o.m_end && o.m_end.get() < m_offset;
+    if (!o.m_end) return m_end.get() < o.m_offset;
+    return m_end.get() < o.m_offset || o.m_end.get() < m_offset;
+  }
+
+  /// @brief Widen this interval to include another interval on the same node.
+  void mergeIntervalInPlace(const Cell &o) {
+    assert(m_node == o.m_node);
+    if (o.m_offset < m_offset) m_offset = o.m_offset;
+    if (!m_end || !o.m_end) {
+      m_end = boost::none;
+    } else if (o.m_end.get() > m_end.get()) {
+      m_end = o.m_end;
+    }
+  }
+
+  /**
+   * @brief Make this cell point to a node at given offset
+   * @param n The target node
+   * @param offset Byte offset into the target node
+   */
   void pointTo(Node &n, unsigned offset);
 
+  /**
+   * @brief Make this cell point to a node interval.
+   * @param n The target node
+   * @param start Start byte offset into the target node
+   * @param end Inclusive end byte offset, none means infinity
+   */
+  void pointTo(Node &n, unsigned start, boost::optional<unsigned> end);
+
+  /**
+   * @brief Make this cell point to the same location as another cell
+   * @param c The target cell
+   * @param offset Additional offset to add
+   */
   void pointTo(const Cell &c, unsigned offset = 0) {
     assert(!c.isNull());
     Node *n = c.getNode();
-    pointTo(*n, c.getRawOffset() + offset);
+    auto end = c.getRawEndOffset();
+    if (end) end = end.get() + offset;
+    pointTo(*n, c.getRawOffset() + offset, end);
   }
 
   inline bool hasLink(Field offset) const;
@@ -397,6 +519,7 @@ public:
   void swap(Cell &o) {
     std::swap(m_node, o.m_node);
     std::swap(m_offset, o.m_offset);
+    std::swap(m_end, o.m_end);
   }
 
   /// pretty-printer of a cell
@@ -510,6 +633,8 @@ public:
   // TODO: Investigate why flat_map is slower for accessed_types_type.
   using accessed_types_type = llvm::DenseMap<unsigned, Set>;
   using links_type = boost::container::flat_map<Field, CellRef>;
+  /// Set of collapsed interval cells.
+  using collapsed_cells_type = boost::container::flat_set<Cell>;
 
   // Iterator for graph interface... Defined in GraphTraits.h
   using iterator = NodeIterator<Node>;
@@ -523,6 +648,11 @@ public:
   NodeType getNodeType() const { return m_nodeType; }
 
   const links_type &getLinks() const { return m_links; }
+
+  const collapsed_cells_type &getCollapsedCells() const {
+    return m_collapsedCells;
+  }
+  const collapsed_cells_type &getChunks() const { return getCollapsedCells(); }
 
 private:
   links_type &getLinks() { return m_links; }
@@ -552,13 +682,22 @@ protected:
   };
 
 private:
-  /// known type of every offset/field
-  accessed_types_type m_accessedTypes;
-  /// destination of every offset/field
-  links_type m_links;
+  accessed_types_type
+      m_accessedTypes; ///< Map from offset to types accessed at that offset
+  links_type m_links;  ///< Map from field to cells pointed to by that field
+  /// Set of collapsed interval cells in this node.
+  ///
+  /// BU/TD invariant: Graph::import and the Cloner rebuild cells with
+  /// singleton offsets, so per-cell interval WIDTHS are intraprocedural;
+  /// only this node-level interval set survives cloning. Offset
+  /// canonicalization (Offset::getNumericOffset) therefore remains the
+  /// sole interprocedural consumer of these intervals.
+  collapsed_cells_type m_collapsedCells;
 
-  /// known size
-  unsigned m_size;
+  unsigned m_size; ///< Size of the memory object in bytes; array stride for
+                   ///< array nodes
+  boost::optional<unsigned>
+      m_arrayMaxSize; ///< Known upper bound for array extent in bytes
 
   /// allocation sites for the node
   using AllocaSet = boost::container::flat_set<const llvm::Value *>;
@@ -592,6 +731,30 @@ private:
   /// should use unifyAt() that has less stringent preconditions.
   void pointTo(Node &node, const Offset &offset);
 
+  void joinCollapsedCells(const Node &node, const Offset &offset);
+
+  /**
+   * @brief Partially collapse offsets in a given range
+   *
+   * Merges all fields in [start, end] into a single one.
+   *
+   * @param start Start byte offset (inclusive)
+   * @param end End byte offset (inclusive)
+   * @param tag Debug tag for tracking collapse reasons
+   */
+  void partialCollapseOffsets(unsigned start, boost::optional<unsigned> end,
+                              int tag /*= -2*/);
+
+  /**
+   * @brief Merge c into m_collapsedCells maintaining disjoint intervals
+   * @param c The interval cell to be added
+   */
+  void mergeCollapsedCellIntoSet(Cell &c);
+
+  /// True iff the collapsed-cell set denotes a fully collapsed node
+  /// (exactly one interval, starting at 0, unbounded).
+  bool areCollapsedCellsShownCollapsed() const;
+
   Cell &getLink_(const Field &_f);
 
   /// Adds a set of types for a field at a given offset
@@ -605,6 +768,9 @@ private:
   void growSize(const Offset &offset, const llvm::Type *t);
   Node &setArray(bool v = true) {
     m_nodeType.array = v;
+    if (!v) {
+      m_arrayMaxSize = boost::none;
+    }
     return *this;
   }
 
@@ -663,16 +829,34 @@ public:
   bool isIncomplete() const { return m_nodeType.incomplete; }
   bool isUnknown() const { return m_nodeType.unknown; }
 
-  Node &setArraySize(unsigned sz) {
+  Node &setArraySize(unsigned sz) { return setArraySize(sz, boost::none); }
+
+  /**
+   * @brief Set this node as an array with a stride and an optional extent
+   *
+   * The existing m_size value remains the array stride used for modulo offset
+   * adjustment. maxSize tracks a statically-known upper bound on the array
+   * extent in bytes when available (consumed by the interval-bounded
+   * unification in partial collapse).
+   *
+   * @param sz Array stride in bytes
+   * @param maxSize Known upper bound for array extent in bytes, if any
+   * @return Reference to this node
+   */
+  Node &setArraySize(unsigned sz, boost::optional<unsigned> maxSize) {
     assert(!isArray());
     assert(!isForwarding());
     assert(m_size <= sz);
 
     setArray(true);
     m_size = sz;
+    m_arrayMaxSize = maxSize;
     return *this;
   }
 
+  boost::optional<unsigned> getArrayMaxSize() const { return m_arrayMaxSize; }
+
+  /// @brief Check if this node represents an array
   bool isArray() const { return m_nodeType.array; }
 
   Node &setOffsetCollapsed(bool v = true) {
@@ -742,6 +926,15 @@ public:
 
   unsigned getNumLinks() const { return m_links.size(); }
 
+  /// @brief Get the total number of collapsed interval cells in this node
+  unsigned getNumCollapsedCells() const { return m_collapsedCells.size(); }
+  unsigned getNumChunks() const { return getNumCollapsedCells(); }
+
+  /**
+   * @brief Get the cell pointed to by a field
+   * @param f The field
+   * @return The target cell
+   */
   const Cell &getLink(Field f) const;
 
   void setLink(const Field _f, const Cell &c);
@@ -760,7 +953,15 @@ public:
   bool isVoid() const { return m_accessedTypes.empty(); }
   bool isEmtpyAccessedType() const;
 
-  /// Nodes that originate from operations on nullptr, e.g. gep(null, Offset).
+  bool isPartialCollapsed() const { return m_collapsedCells.size() >= 1; }
+
+  /**
+   * @brief Check if this node originates from null pointer operations
+   *
+   * E.g., gep(null, offset) creates a null allocation node.
+   *
+   * @return true if this is a null allocation
+   */
   bool isNullAlloc() const { return m_nodeType.null; }
   Node &setNullAlloc(bool v = true) {
     m_nodeType.null = v;
@@ -812,45 +1013,93 @@ public:
   void viewGraph();
 };
 
-bool Node::isForwarding() const { return !m_forward.isNull(); }
+/// @brief Check if node is forwarding (inline implementation)
+inline bool Node::isForwarding() const { return !m_forward.isNull(); }
 
-Cell &Node::getForwardDest() { return m_forward; }
-const Cell &Node::getForwardDest() const { return m_forward; }
+/// @brief Get forwarding destination (inline implementation)
+inline Cell &Node::getForwardDest() { return m_forward; }
 
-bool Cell::hasLink(Field offset) const {
+/// @brief Get forwarding destination const (inline implementation)
+inline const Cell &Node::getForwardDest() const { return m_forward; }
+
+/**
+ * @brief Check if cell has a link at offset (inline implementation)
+ * @param offset Field offset to check
+ * @return true if link exists
+ */
+inline bool Cell::hasLink(Field offset) const {
   return m_node && getNode()->hasLink(offset.addOffset(m_offset));
 }
 
-const Cell &Cell::getLink(Field offset) const {
+/**
+ * @brief Get link at offset (inline implementation)
+ * @param offset Field offset
+ * @return The target cell
+ */
+inline const Cell &Cell::getLink(Field offset) const {
   assert(m_node);
   // -- call Node::getLink() const
   return static_cast<const Node *>(getNode())->getLink(
       offset.addOffset(m_offset));
 }
 
-void Cell::setLink(Field offset, const Cell &c) {
+/**
+ * @brief Set link at offset (inline implementation)
+ * @param offset Field offset
+ * @param c Target cell
+ */
+inline void Cell::setLink(Field offset, const Cell &c) {
   getNode()->setLink(offset.addOffset(m_offset), c);
 }
 
-void Cell::addLink(Field offset, const Cell &c) {
+/**
+ * @brief Add link at offset (inline implementation)
+ * @param offset Field offset
+ * @param c Cell to add/unify
+ */
+inline void Cell::addLink(Field offset, const Cell &c) {
   getNode()->addLink(offset.addOffset(m_offset), c);
 }
 
-void Cell::addAccessedType(unsigned offset, llvm::Type *t) {
+/**
+ * @brief Add accessed type (inline implementation)
+ * @param offset Byte offset
+ * @param t Type accessed
+ */
+inline void Cell::addAccessedType(unsigned offset, llvm::Type *t) {
   getNode()->addAccessedType(m_offset + offset, t);
 }
 
-void Cell::growSize(unsigned o, llvm::Type *t) {
+/**
+ * @brief Grow cell size (inline implementation)
+ * @param o Offset
+ * @param t Type at offset
+ */
+inline void Cell::growSize(unsigned o, llvm::Type *t) {
   assert(!isNull());
   Node::Offset offset(*getNode(), m_offset + o);
   getNode()->growSize(offset, t);
 }
 
-Node *Node::getNode() { return isForwarding() ? m_forward.getNode() : this; }
-
-const Node *Node::getNode() const {
+/**
+ * @brief Get non-forwarding node (inline implementation)
+ *
+ * Follows forwarding chain to find actual node.
+ *
+ * @return Pointer to actual node
+ */
+inline Node *Node::getNode() {
   return isForwarding() ? m_forward.getNode() : this;
 }
+
+/**
+ * @brief Get non-forwarding node const (inline implementation)
+ * @return Pointer to actual node
+ */
+inline const Node *Node::getNode() const {
+  return isForwarding() ? m_forward.getNode() : this;
+}
+
 } // namespace seadsa
 
 namespace llvm {
@@ -870,6 +1119,9 @@ template <> struct hash<seadsa::Cell> {
     size_t seed = 0;
     boost::hash_combine(seed, c.getNode());
     boost::hash_combine(seed, c.getRawOffset());
+    const auto end = c.getRawEndOffset();
+    boost::hash_combine(seed, static_cast<bool>(end));
+    if (end) boost::hash_combine(seed, end.get());
     // boost::hash_combine(seed, c.getType().asTuple());
     return seed;
   }

--- a/lib/seadsa/DsaLocal.cc
+++ b/lib/seadsa/DsaLocal.cc
@@ -20,6 +20,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "llvm/ADT/DenseSet.h"
+#include <optional>
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Analysis/CFG.h"
@@ -27,6 +28,7 @@
 #include "llvm/Analysis/MemoryBuiltins.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
+#include "llvm/IR/ConstantRange.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
@@ -41,6 +43,8 @@
 #include "seadsa/support/Debug.h"
 
 #include "boost/range/algorithm/reverse.hpp"
+
+#include <limits>
 
 using namespace llvm;
 
@@ -168,9 +172,14 @@ Function *getCalledFunction(CallBase &CB) {
 
 namespace {
 // forward declaration
-std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
-                                              ArrayRef<Value *> Indicies,
-                                              const DataLayout &dl);
+struct GepOffset {
+  int64_t noffset = 0;
+  uint64_t stride = 0;
+  std::optional<uint64_t> arraySize;
+};
+
+GepOffset computeGepOffset(Type *srcElementTy, ArrayRef<Value *> Indicies,
+                           const DataLayout &dl);
 
 /*****************************************************************************/
 /* BlockBuilderBase */
@@ -404,7 +413,6 @@ public:
 
 void InterBlockBuilder::visitPHINode(PHINode &PHI) {
   if (!PHI.getType()->isPointerTy()) return;
-
   assert(m_graph.hasCell(PHI));
   seadsa::Cell &phi = m_graph.mkCell(PHI, seadsa::Cell());
   for (unsigned i = 0, e = PHI.getNumIncomingValues(); i < e; ++i) {
@@ -678,7 +686,6 @@ void IntraBlockBuilder::visitAllocaInst(AllocaInst &AI) {
 void IntraBlockBuilder::visitSelectInst(SelectInst &SI) {
   using namespace seadsa;
   if (isSkip(SI)) return;
-
   assert(!m_graph.hasCell(SI));
 
   Cell thenC = valueCell(*SI.getOperand(1));
@@ -691,6 +698,9 @@ void IntraBlockBuilder::visitSelectInst(SelectInst &SI) {
 
 void IntraBlockBuilder::visitLoadInst(LoadInst &LI) {
   using namespace seadsa;
+
+  /// What we do here is:
+  /// create a link from cell \p base to cell \p val
 
   // -- skip read from NULL
   if (BlockBuilderBase::isNullConstant(*LI.getPointerOperand())) return;
@@ -817,6 +827,21 @@ void IntraBlockBuilder::visitAtomicRMWInst(AtomicRMWInst &I) {
 
 void IntraBlockBuilder::visitStoreInst(StoreInst &SI) {
   using namespace seadsa;
+  /// if type is ptr, then store is for:
+  ///    ptr = &value; in the paper
+  /// What we do here is:
+  /// create a link from cell \p base to cell \p val
+  /* 
+  Example: Pointer Chain
+  ======================
+  Cell (base) [M]
+  ├─ node: Node1 (with size growth)
+  └─ offset: 0
+        ├─ m_links[Field(0, PTR)]  →  Cell (dest)
+        │                               ├─ node: Node2
+        │                               └─ offset: 0
+        └─ accessedTypes[0] = <Ty>
+  */
 
   // -- skip store into NULL
   if (BlockBuilderBase::isNullConstant(
@@ -891,16 +916,26 @@ template <typename T> T gcd(T a, T b) {
   return a;
 }
 
-/**
-   Computes an offset of a gep instruction for a given type and a
-   sequence of indicies.
+static boost::optional<unsigned>
+toUnsignedArraySize(std::optional<uint64_t> arraySize) {
+  if (!arraySize) return boost::none;
+  if (*arraySize > std::numeric_limits<unsigned>::max()) return boost::none;
+  return static_cast<unsigned>(*arraySize);
+}
 
-   The first element of the pair is the fixed offset. The second is
-   a gcd of the variable offset.
+/**
+   Computes an offset of a gep instruction for a given source element type
+   and a sequence of indicies.
+
+   GepOffset::noffset is the fixed offset. GepOffset::stride is a gcd of the
+   variable offset. GepOffset::arraySize is the first statically-known nonzero
+   array extent in bytes along the GEP type path, if any. (A per-index
+   value-range refinement of the reachable byte interval is possible here --
+   e.g. via computeConstantRange on non-constant indices -- and is left as a
+   future precision refinement.)
  */
-std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
-                                              ArrayRef<Value *> Indicies,
-                                              const DataLayout &dl) {
+GepOffset computeGepOffset(Type *srcElementTy, ArrayRef<Value *> Indicies,
+                           const DataLayout &dl) {
 
   // numeric offset
   int64_t noffset = 0;
@@ -908,14 +943,23 @@ std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
   // divisor
   uint64_t divisor = 0;
 
+  std::optional<uint64_t> arraySize;
+
   generic_gep_type_iterator<Value *const *> TI =
       gep_type_begin(srcElementTy, Indicies);
+
+  // Type of the object the current index strides within. The leading index
+  // performs pointer arithmetic over srcElementTy itself, so it has no
+  // enclosing array; afterwards this follows the iterator's descent and is
+  // only consulted to spot statically sized arrays along the path.
+  Type *curTy = nullptr;
 
   for (unsigned CurIDX = 0, EndIDX = Indicies.size(); CurIDX != EndIDX;
        ++CurIDX, ++TI) {
     if (StructType *STy = TI.getStructTypeOrNull()) {
       unsigned fieldNo = cast<ConstantInt>(Indicies[CurIDX])->getZExtValue();
       noffset += dl.getStructLayout(STy)->getElementOffset(fieldNo);
+      curTy = STy->getElementType(fieldNo);
     } else {
       // The type strided over by index CurIDX. For CurIDX == 0 that is
       // srcElementTy itself -- the first index strides over the source
@@ -924,6 +968,14 @@ std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
       // the *pointer* type) would consume the first index twice.
       Type *Ty = TI.getIndexedType();
       assert(Ty && "Type is neither PointerType nor SequentialType");
+
+      // Remember the extent of the array this index strides within, when it
+      // is a statically sized array (the leading pointer-arithmetic level has
+      // no such bound).
+      if (curTy && curTy->isArrayTy()) {
+        uint64_t ext = dl.getTypeStoreSize(curTy);
+        if (!arraySize && ext != 0) arraySize = ext;
+      }
 
       uint64_t sz = dl.getTypeStoreSize(Ty);
       if (ConstantInt *ci = dyn_cast<ConstantInt>(Indicies[CurIDX])) {
@@ -935,15 +987,22 @@ std::pair<int64_t, uint64_t> computeGepOffset(Type *srcElementTy,
           // XXX can probably do better. Some negative indexes are positive
           // offsets
           // XXX others are just moving between array cells
-          return std::make_pair(0, 1);
+          return {0, 1, arraySize};
         }
         noffset += (uint64_t)arrayIdx * sz;
       } else
         divisor = divisor == 0 ? sz : gcd(divisor, sz);
+
+      curTy = Ty;
     }
   }
 
-  return std::make_pair(noffset, divisor);
+  LOG("dsa-gep-compute", errs() << "computeGepOffset: offset=" << noffset
+                                << ", divisor=" << divisor
+                                << ", array-size="; if (arraySize) errs() << *arraySize;
+      else errs() << "none"; errs() << "\n";);
+
+  return {noffset, divisor, arraySize};
 }
 
 /// Computes offset into an indexed type
@@ -1036,19 +1095,31 @@ void BlockBuilderBase::visitGep(const Value &gep, const Value &ptr,
   }
 
   auto off = computeGepOffset(srcElementType, indicies, m_dl);
-  if (off.first < 0) {
-    if (base.getOffset() + off.first >= 0) {
+  // off contains (offset, divisor) plus the first static array extent seen.
+  /// @example
+  /// %st.A = type { i32, [50 x %st.B] }
+  /// %st.B = type { i32, i32, i32 }
+  ///   %7 = getelementptr inbounds [100 x %st.A],
+  ///           ptr %1, i64 0, i64 %5, i32 1, i64 %6, i32 2
+  ///   off.noffset = 1 x sizeof(i32) + 2 x sizeof(i32) = 12
+  ///   off.stride = gcd(sizeof(%st.A), sizeof(%st.B)) = 4
+  if (off.noffset < 0) {
+    // Q: why offset is negative?
+    // @example
+    // %.02.i.i18 = getelementptr inbounds i8, ptr %tmp50, i64 -1
+    // where in source code is a pointer arithmetic like %tmp50--
+    if (base.getOffset() + off.noffset >= 0) {
       m_graph.mkCell(gep,
-                     seadsa::Cell(*baseNode, base.getOffset() + off.first));
+                     seadsa::Cell(*baseNode, base.getOffset() + off.noffset));
       return;
     } else {
       // create a new node for gep
       seadsa::Node &n = m_graph.mkNode();
       // gep points to offset 0
       m_graph.mkCell(gep, seadsa::Cell(n, 0));
-      // base of gep is at -off.first
-      // e.g., off.first is -16, then base is unified at offset 16 with n
-      n.unifyAt(*baseNode, -(base.getOffset() + off.first));
+      // base of gep is at -off.noffset
+      // e.g., off.noffset is -16, then base is unified at offset 16 with n
+      n.unifyAt(*baseNode, -(base.getOffset() + off.noffset));
       return;
     }
     // XXX This is now unreachable
@@ -1058,29 +1129,97 @@ void BlockBuilderBase::visitGep(const Value &gep, const Value &ptr,
     // XXX current work-around
     // XXX If the offset is negative, convert to an array of stride 1
     LOG("dsa", errs() << "Warning: collapsing negative gep to array: ("
-                      << off.first << ", " << off.second << ")\n"
+                      << off.noffset << ", " << off.stride << ")\n"
                       << "gep: " << gep << "\n"
-                      << "bace cell: " << base << "\n";);
-    off = std::make_pair(0, 1);
+                      << "base cell: " << base << "\n";);
+    off = {0, 1, off.arraySize};
   }
-  if (off.second) {
+  if (off.stride) { // array with common divisor for computing new size
     // create a node representing the array
     seadsa::Node &n = m_graph.mkNode();
-    n.setArraySize(off.second);
-    // result of the gep points into that array at the gep offset
-    // plus the offset of the base
-    m_graph.mkCell(gep, seadsa::Cell(n, off.first + base.getRawOffset()));
-    // finally, unify array with the node of the base
-    n.unify(*baseNode);
+    boost::optional<unsigned> arraySize = toUnsignedArraySize(off.arraySize);
+    LOG("dsa-array-bound",
+        errs() << "gep creates sequence node: stride=" << off.stride
+               << ", array-size=";
+        if (arraySize)
+          errs() << arraySize.get();
+        else if (off.arraySize)
+          errs() << *off.arraySize << " (too large for unsigned)";
+        else
+          errs() << "none";
+        errs() << ", noffset=" << off.noffset
+               << ", base-offset=" << base.getRawOffset() << "\n";);
+    n.setArraySize(off.stride, arraySize);
+    unsigned o = static_cast<unsigned>(off.noffset) + base.getRawOffset();
+    if (seadsa::IsPartialCollapseActive() && !baseNode->isArray() && o > 0) {
+      /*
+      Nonsequence Node n (size=12):
+        +-------+-------+-------+-------+
+        |   0   |   4   |   8   |  12   |  (offsets)
+        +-------+-------+-------+-------+
+        | field1| field2| field3| field4|
+        +-------+-------+-------+-------+
+                        |
+      Sequence Node *this (array, sz=stride=off.stride,
+      arraySize=off.arraySize):
+                        +-----------------------+
+                        |       0 ... m * sz    |
+        |-- offset ---> +-----------------------+
+                        |        elements       |
+                        +-----------------------+
+     */
+      auto c = seadsa::Cell(baseNode, o);
+      m_graph.mkCell(gep, c);
+      baseNode->unifyAt(n, o);
+    } else {
+      // result of the gep points into that array at the gep offset
+      // plus the offset of the base
+      auto c = seadsa::Cell(n, o);
+      m_graph.mkCell(gep, c);
+      // finally, unify array with the node of the base
+      n.unify(*baseNode);
+    }
   } else {
-    m_graph.mkCell(gep, seadsa::Cell(base, off.first));
+    // a simple case for just computing a new cell based on offset.
+    // here we still access the same abstract memory obj (node)
+    m_graph.mkCell(gep, seadsa::Cell(base, off.noffset));
   }
 }
 
 void IntraBlockBuilder::visitGetElementPtrInst(GetElementPtrInst &I) {
   Value &ptr = *I.getPointerOperand();
+  // <result> = getelementptr <ty>, ptr <ptrval> {, <ty> <idx>}*
+  // What we do here is:
+  // result = base + (sizeof(type) * idx0) + offset({idx1, ...})
+  // Gep 
+  /* 
+  Example: Pointer Chain
+  ======================
+  Cell (base)
+  ├─ node: Node1
+  └─ offset: a
+       ||
+       ||
+       vv
+  Cell (new)
+  ├─ node: Node1 (update size growth if needed)
+  └─ offset: b
 
-  if (isa<ConstantExpr>(ptr)) {
+  with b = a + sizeof(type) * idx0 + offset({idx1, ...})
+  cell new will be created if res ptr is not in the graph yet
+  otherwise, unify the exisiting cell with the new cell created
+  the new cell is created based on the base cell with updated offset
+  */
+
+  // in LLVM IR, a gep instruction can take a constant pointer if
+  // ptr is a global value
+  // e.g.
+  // @array = global [10 x i32] zeroinitializer
+  // @fifth = global i32* getelementptr ([10 x i32], [10 x i32]* @array, i64 0, i64 5)
+  // so here we need to compute the intermediate pointer so
+  // the pointer at the end will has the 
+
+  if (isa<ConstantExpr>(ptr)) { // ptr is a constant
     if (auto *g = dyn_cast<GEPOperator>(&ptr)) {
       // Visit nested constant GEP first.
       SmallVector<Value *, 8> indicies(g->op_begin() + 1, g->op_end());

--- a/lib/seadsa/DsaPrinter.cc
+++ b/lib/seadsa/DsaPrinter.cc
@@ -51,6 +51,22 @@ using namespace llvm;
 
 namespace seadsa {
 
+static bool hasNonSingletonCollapsedCell(const Node &node) {
+  for (const auto &cell : node.getCollapsedCells()) {
+    auto end = cell.getEndOffset();
+    if (!end || cell.getStartOffset() != end.get()) return true;
+  }
+  return false;
+}
+
+template <typename CollapsedCell>
+static void writeCollapsedCellAsField(const CollapsedCell &cell,
+                                      raw_ostream &o) {
+  auto end = cell.getEndOffset();
+  o << "[" << cell.getStartOffset() << "-"
+    << (end ? std::to_string(end.get()) : "+oo") << "]:raw";
+}
+
 namespace internals {
 
 /* XXX: The API of llvm::GraphWriter is not flexible enough.
@@ -315,6 +331,10 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
         OS << "fillcolor=chocolate1, style=filled";
       } else if (N->isTypeCollapsed() && seadsa::g_IsTypeAware) {
         OS << "fillcolor=darkorchid2, style=filled";
+      } else if (seadsa::hasNonSingletonCollapsedCell(*N)) {
+        OS << "fillcolor=gold2, style=filled";
+      } else if (N->isPartialCollapsed()) {
+        OS << "fillcolor=palegreen2, style=filled";
       } else {
         OS << "fillcolor=gray, style=filled";
       }
@@ -352,10 +372,19 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
       } else {
         // Go through all the types, and just print them.
         const auto &ts = N->types();
+        const auto &collapsedCells = N->getCollapsedCells();
+        auto cellIt = collapsedCells.begin();
+        auto cellEnd = collapsedCells.end();
         bool firstType = true;
         OS << "{";
-        if (ts.begin() != ts.end()) {
+        if (ts.begin() != ts.end() || cellIt != cellEnd) {
           for (auto ii = ts.begin(), ee = ts.end(); ii != ee; ++ii) {
+            while (cellIt != cellEnd && cellIt->getStartOffset() <= ii->first) {
+              if (!firstType) OS << ",";
+              firstType = false;
+              seadsa::writeCollapsedCellAsField(*cellIt, OS);
+              ++cellIt;
+            }
             if (!firstType) OS << ",";
             firstType = false;
             OS << ii->first << ":"; // offset
@@ -368,6 +397,12 @@ struct DOTGraphTraits<seadsa::Graph *> : public DefaultDOTGraphTraits {
               }
             } else
               OS << "void";
+          }
+          while (cellIt != cellEnd) {
+            if (!firstType) OS << ",";
+            firstType = false;
+            seadsa::writeCollapsedCellAsField(*cellIt, OS);
+            ++cellIt;
           }
         } else {
           OS << "void";

--- a/lib/seadsa/Graph.cc
+++ b/lib/seadsa/Graph.cc
@@ -8,6 +8,8 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
+#include <limits>
 #include <set>
 #include <string>
 
@@ -27,12 +29,35 @@ using namespace llvm;
 
 namespace seadsa {
 bool g_IsTypeAware;
+bool g_IsPartialCollapseEnabled;
 }
 
 static llvm::cl::opt<bool, true> XTypeAware(
     "sea-dsa-type-aware", llvm::cl::desc("Enable SeaDsa type awareness"),
     llvm::cl::location(seadsa::g_IsTypeAware), llvm::cl::init(false));
 
+static llvm::cl::opt<bool, true>
+    XPartialCollapse(
+        "sea-dsa-partial-collapse",
+        llvm::cl::desc("Enable SeaDsa partial offset collapse (interval "
+                       "cells); requires --sea-dsa-type-aware, otherwise "
+                       "ignored with a warning"),
+        llvm::cl::location(seadsa::g_IsPartialCollapseEnabled),
+        llvm::cl::init(false));
+
+bool seadsa::IsPartialCollapseActive() {
+  if (!g_IsPartialCollapseEnabled) return false;
+  if (!g_IsTypeAware) {
+    static bool warned = false;
+    if (!warned) {
+      warned = true;
+      llvm::errs() << "sea-dsa WARNING: --sea-dsa-partial-collapse requires "
+                      "--sea-dsa-type-aware; partial collapse is disabled.\n";
+    }
+    return false;
+  }
+  return true;
+}
 namespace seadsa {
 
 class DsaAllocator {
@@ -86,12 +111,14 @@ Graph::Graph(const llvm::DataLayout &dl, SetFactory &sf, bool is_flat)
 Graph::~Graph() = default;
 Node::Node(Graph &g)
     : m_graph(&g), m_unique_scalar(nullptr), m_has_once_unique_scalar(false),
-      m_size(0), m_id(++m_id_factory) {
+      m_size(0), m_arrayMaxSize(boost::none),
+      m_id(++m_id_factory) {
   setTypeCollapsed(!g_IsTypeAware);
 }
 
 Node::Node(Graph &g, const Node &n, bool cpLinks, bool cpAllocSites)
-    : m_graph(&g), m_unique_scalar(n.m_unique_scalar), m_size(n.m_size) {
+    : m_graph(&g), m_unique_scalar(n.m_unique_scalar), m_size(n.m_size),
+      m_arrayMaxSize(n.m_arrayMaxSize) {
   assert(!n.isForwarding());
 
   // -- fresh id
@@ -102,6 +129,12 @@ Node::Node(Graph &g, const Node &n, bool cpLinks, bool cpAllocSites)
 
   // -- copy types
   joinAccessedTypes(0, n);
+
+  // -- copy collapsed interval cells
+  for (auto &ck : n.m_collapsedCells) {
+    m_collapsedCells.insert(
+        Cell(this, ck.getRawStartOffset(), ck.getRawEndOffset()));
+  }
 
   // -- copy allocation sites
   if (cpAllocSites) joinAllocSites(n.m_alloca_sites);
@@ -127,6 +160,9 @@ unsigned Node::Offset::getNumericOffset() const {
   assert(!n->isForwarding());
   if (n->isOffsetCollapsed()) return 0;
   if (n->isArray()) return offset % n->size();
+  for (auto &ck : n->getCollapsedCells()) {
+    if (ck.includes(offset)) { return ck.getStartOffset(); }
+  }
   return offset;
 }
 
@@ -187,6 +223,9 @@ void Node::addAccessedType(unsigned off, llvm::Type *type) {
     Offset offset(*this, o);
     growSize(offset, t);
     if (isOffsetCollapsed()) return;
+    for (auto &ck : getCollapsedCells()) {
+      if (ck.includes(offset.getNumericOffset())) { return; }
+    }
 
     // -- recursively expand structures
     if (const StructType *sty = dyn_cast<const StructType>(t)) {
@@ -320,12 +359,38 @@ void Node::collapseTypes(int tag) {
   pointTo(n, Offset(n, 0));
 }
 
+void Node::joinCollapsedCells(const Node &node, const Offset &offset) {
+  LOG("dsa-collapse", errs() << "Joining collapsed cells between " << &node
+                             << " and " << this << " at offset "
+                             << offset.getNumericOffset() << "\n";);
+  // precondition, each node has disjoint interval cells
+  for (auto &ck : node.m_collapsedCells) {
+    LOG("dsa-collapse",
+        errs() << "Found collapsed cell [" << ck.getOffset() << ", ";
+        auto end = ck.getEndOffset(); if (end) errs() << end.get();
+        else errs() << "+oo"; errs() << "] at node " << ck.getNode() << "\n";);
+    unsigned newStart = offset.getNumericOffset() + ck.getOffset();
+    boost::optional<unsigned> endOffset = ck.getEndOffset();
+    if (endOffset) { endOffset = offset.getNumericOffset() + endOffset.get(); }
+    // unsigned newEnd = offset.getNumericOffset() + ;
+    partialCollapseOffsets(newStart, endOffset, __LINE__);
+  }
+}
+
+/// @brief redirect edges from current node to another node
+///        in paper, this is the redirectEdges function
+/// @param node the target node
+/// @param offset Byte offset into the target node
 void Node::pointTo(Node &node, const Offset &offset) {
   // -- possible under flat dsa graph
   if (&node == this) return;
   assert(&node == &offset.node());
   assert(&node != this);
   assert(!isForwarding());
+
+  LOG("dsa-forward", errs() << "Forwarding links from " << this << " to "
+                            << &node << " at offset "
+                            << offset.getNumericOffset() << "\n";);
 
   // -- reset unique scalar at the destination
   if (offset.getNumericOffset() != 0) node.setUniqueScalar(nullptr);
@@ -363,17 +428,29 @@ void Node::pointTo(Node &node, const Offset &offset) {
   // -- merge allocation sites
   node.joinAllocSites(m_alloca_sites);
 
+  // -- merge all the collapsed interval cells
+  if (seadsa::IsPartialCollapseActive()) {
+    node.joinCollapsedCells(*this, offset);
+  }
+
   // -- move all the links
+  LOG("dsa-forward", errs() << "Moving links\n";);
   for (auto &kv : m_links) {
     if (kv.second->isNull()) continue;
+    LOG("dsa-forward",
+        errs() << "link: " << kv.first << " -> " << *kv.second << "\n";);
 
     m_forward.addLink(kv.first, *kv.second);
   }
 
+  LOG("dsa-forward", errs() << "after add node: " << node << "\n";);
+
   // reset current node
   m_alloca_sites.clear();
   m_size = 0;
+  m_arrayMaxSize = boost::none;
   m_links.clear();
+  m_collapsedCells.clear();
   m_accessedTypes.clear();
   m_unique_scalar = nullptr;
   m_nodeType.reset();
@@ -474,8 +551,11 @@ void Node::addLink(Field _f, const Cell &c) {
 /// Unify a given node into the current node at a specified offset.
 /// Might cause collapse.
 void Node::unifyAt(Node &n, unsigned o) {
-  assert(!isForwarding());
-  assert(!n.isForwarding());
+  assert(!isForwarding());   // current node is not forwarding node
+  assert(!n.isForwarding()); // unfied node is not forwarding node
+  // NOTE: above two assertions indicate two nodes are representative nodes
+  LOG("dsa-unify", errs() << "Unifying " << n << " into " << *this
+                          << " at offset " << o << "\n";);
 
   // collapse before merging with a collapsed node
   if (!isOffsetCollapsed() && n.isOffsetCollapsed()) {
@@ -484,7 +564,9 @@ void Node::unifyAt(Node &n, unsigned o) {
     return;
   }
 
-  Offset offset(*this, o);
+  Offset offset(*this, o); // o' = o \circleplus_*this 0
+  LOG("dsa-unify",
+      errs() << "Adjusted offset: " << offset.getNumericOffset() << "\n";);
 
   if (!isOffsetCollapsed() && !n.isOffsetCollapsed() && n.isArray() &&
       !isArray()) {
@@ -495,9 +577,41 @@ void Node::unifyAt(Node &n, unsigned o) {
     }
     // -- cannot merge array at non-zero offset
     else {
-      collapseOffsets(__LINE__);
-      getNode()->unifyAt(*n.getNode(), o);
-      return;
+      if (seadsa::IsPartialCollapseActive()) {
+        const unsigned start = offset.getNumericOffset();
+        boost::optional<unsigned> end = boost::none;
+        LOG("dsa-array-bound",
+            errs() << "partial-collapse array merge: start=" << start
+                   << ", seq-stride=" << n.size() << ", seq-array-size=";
+            if (auto arrayMaxSize = n.getArrayMaxSize())
+              errs() << arrayMaxSize.get();
+            else
+              errs() << "none";
+            errs() << "\n";);
+        if (auto arrayMaxSize = n.getArrayMaxSize()) {
+          const unsigned stride = n.size();
+          uint64_t arrayLastOffset =
+              arrayMaxSize.get() >= stride ? arrayMaxSize.get() - stride : 0;
+          uint64_t upper = static_cast<uint64_t>(start) + arrayLastOffset;
+          if (upper <= std::numeric_limits<unsigned>::max())
+            end = static_cast<unsigned>(upper);
+        }
+        LOG("dsa-array-bound",
+            errs() << "partial-collapse computed interval: [" << start << ",";
+            if (end)
+              errs() << end.get();
+            else
+              errs() << "+oo";
+            errs() << "]\n";);
+        partialCollapseOffsets(start, end, __LINE__);
+        n.setArray(false);
+        LOG("dsa-unify",
+            errs() << "<" << offset.getNumericOffset() << ", " << n << "\n";);
+      } else {
+        collapseOffsets(__LINE__);
+        getNode()->unifyAt(*n.getNode(), o);
+        return;
+      }
     }
   } else if (isArray() && n.isArray()) {
     // merge larger sized array into 0 offset of the smaller array
@@ -542,7 +656,7 @@ void Node::unifyAt(Node &n, unsigned o) {
 
   if (&n == this) {
     // -- merging the node into itself at a different offset
-    if (offset.getNumericOffset() > 0) collapseOffsets(__LINE__);
+    if (offset.getNumericOffset() > 0) { collapseOffsets(__LINE__); }
     return;
   }
 
@@ -550,6 +664,113 @@ void Node::unifyAt(Node &n, unsigned o) {
   assert(!n.isForwarding());
   // -- move everything from n to this node
   n.pointTo(*this, offset);
+}
+
+void Node::mergeCollapsedCellIntoSet(Cell &ck) {
+  auto it = m_collapsedCells.begin();
+  auto end_it = m_collapsedCells.end();
+
+  // Single pass: merge and collect iterators to erase
+  std::vector<typename collapsed_cells_type::iterator> toErase;
+
+  for (it = m_collapsedCells.begin(); it != end_it; ++it) {
+    if (!it->isDisjoint(ck)) {
+      ck.mergeIntervalInPlace(*it);
+      toErase.push_back(it);
+    }
+  }
+
+  // Erase in reverse order to maintain iterator validity
+  for (auto rit = toErase.rbegin(); rit != toErase.rend(); ++rit) {
+    m_collapsedCells.erase(*rit);
+  }
+
+  m_collapsedCells.insert(ck);
+}
+
+bool Node::areCollapsedCellsShownCollapsed() const {
+  if (m_collapsedCells.size() != 1) return false;
+  const auto &ck = *m_collapsedCells.begin();
+  if (ck.getStartOffset() != 0) return false;
+
+  auto end = ck.getEndOffset();
+  return !end;
+}
+
+void Node::partialCollapseOffsets(unsigned start, boost::optional<unsigned> end,
+                                  int tag) {
+  if (isOffsetCollapsed()) return;
+  Offset ostart(*this, start);
+  start = ostart.getNumericOffset();
+  if (end) {
+    Offset oend(*this, end.get());
+    end = oend.getNumericOffset();
+  }
+  if (end && start >= end.get()) return;
+  if (start == 0 && end && m_size < end.get()) {
+    collapseOffsets(tag);
+    return;
+  }
+  assert(!FieldType::IsNotTypeAware());
+
+  LOG("dsa-collapse", errs() << "Partial-Offset-Collapse at Line " << tag
+                             << " with offset range [" << start << ", "
+                             << (end ? std::to_string(end.get()) : "+oo")
+                             << "]\n");
+
+  Node::links_type new_links; // remain links that excluded in [start, end)
+                              // unify links within [start, end)
+  SmallVector<std::pair<Field, CellRef>, 16> links_inrange;
+  Cell tmpCell(this, start, end);
+  // -- find collapsed cells if already exists
+  // -- if no collapsed cell exists, collect links to be collapsed
+  // To find a collapsed cell, we need to either create one or extend an
+  // existing one
+  // E.g.
+  //   ck: |----|          ck: |----------|     ck:   |------|    ck: |------|
+  //         |------|            |------|           |------|     |------------|
+  //       start   end         start   end        start   end  start         end
+  //          (a)                 (b)                 (c)              (d)
+  mergeCollapsedCellIntoSet(tmpCell);
+  if (areCollapsedCellsShownCollapsed()) {
+    collapseOffsets(tag);
+    return;
+  }
+  // -- find links within [start, end] to be collapsed
+  // -- find links outside [start, end] and keep them as is
+  for (auto &kv : m_links) {
+    const Field &key = kv.first;
+    const CellRef &c = kv.second;
+    unsigned foff = key.getOffset();
+    if (c->isNull()) { continue; }
+    if (foff >= start && (!end || foff <= end.get())) {
+      // -- field offset is within [start, end], collapse
+      links_inrange.push_back({kv.first, std::move(kv.second)});
+    } else {
+      new_links[kv.first] = std::move(kv.second);
+    }
+  }
+  m_links = std::move(new_links);
+
+  // -- update access types for collapsed cells
+  Node::accessed_types_type new_accessed_types;
+  for (auto &kv : m_accessedTypes) {
+    unsigned toff = kv.first;
+    if (toff < start || (end && toff > end.get())) {
+      new_accessed_types.insert(std::make_pair(toff, std::move(kv.second)));
+    }
+  }
+  m_accessedTypes = std::move(new_accessed_types);
+
+  // -- unify all links within [start, end] into one
+  for (auto &kv : links_inrange) {
+    // The exact byte within the collapsed interval is no longer known.
+    // Canonicalize every in-range link to the collapsed interval start while
+    // preserving its field type.
+    tmpCell.addLink(Field(0, kv.first.getType()), *kv.second);
+  }
+  LOG("dsa-collapse", errs()
+                          << "After partial collapse node: " << *this << "\n";);
 }
 
 /// pre: this simulated by n
@@ -710,6 +931,24 @@ void Node::write(raw_ostream &o) const {
         << "(" << kv.second->getOffset() << "," << kv.second->getNode() << ")";
     }
     o << "] ";
+    if (seadsa::IsPartialCollapseActive()) {
+      first = true;
+      o << " collapsed-cells=[";
+      for (auto &ck : m_collapsedCells) {
+        if (!first)
+          o << ",";
+        else
+          first = false;
+        o << "<" << ck.getOffset() << ",";
+        auto end = ck.getEndOffset();
+        if (end)
+          o << end.get();
+        else
+          o << "+oo";
+        o << ">";
+      }
+      o << "] ";
+    }
     first = true;
     o << " alloca sites=[";
     for (const Value *a : getAllocSites()) {
@@ -728,6 +967,27 @@ void Node::write(raw_ostream &o) const {
   }
 }
 
+/*******************************************************************************
+ ******************         methods for cell            ************************
+ ******************************************************************************/
+void Cell::write(raw_ostream &o) const {
+  getNode();
+  o << "<" << m_offset;
+  if (!m_end || m_end.get() != m_offset) {
+    o << ", ";
+    if (m_end)
+      o << m_end.get();
+    else
+      o << "+oo";
+  }
+  o << ", ";
+  if (m_node)
+    m_node->write(o);
+  else
+    o << "null";
+  o << ">";
+}
+
 void Cell::dump() const {
   write(errs());
   errs() << "\n";
@@ -740,18 +1000,33 @@ bool Cell::isRead() const { return getNode()->isRead(); }
 bool Cell::isModified() const { return getNode()->isModified(); }
 
 void Cell::unify(Cell &c) {
+  LOG("dsa-unify",
+      errs() << "Unifying cell " << c << " into cell " << *this << "\n";);
   if (isNull()) {
     assert(!c.isNull());
     Node *n = c.getNode();
-    pointTo(*n, c.getRawOffset());
-  } else if (c.isNull())
+    pointTo(*n, c.getRawOffset(), c.getRawEndOffset());
+  } else if (c.isNull()) {
     c.unify(*this);
-  else {
+  } else {
     Node &n1 = *getNode();
     unsigned o1 = getRawOffset();
+    boost::optional<unsigned> e1 = getRawEndOffset();
 
     Node &n2 = *c.getNode();
     unsigned o2 = c.getRawOffset();
+    boost::optional<unsigned> e2 = c.getRawEndOffset();
+    if (seadsa::IsPartialCollapseActive() && (&n1) == (&n2)) {
+      unsigned start = std::min(o1, o2);
+      boost::optional<unsigned> end;
+      if (!e1 || !e2)
+        end = boost::none;
+      else
+        end = std::max(e1.get(), e2.get());
+      if (!end || start != end.get())
+        n1.partialCollapseOffsets(start, end, __LINE__);
+      return;
+    }
 
     if (o1 < o2)
       n2.unifyAt(n1, o2 - o1);
@@ -770,7 +1045,9 @@ Node *Cell::getNode() const {
   assert((n == m_node && !m_node->isForwarding()) || m_node->isForwarding());
   if (n != m_node) {
     assert(m_node->isForwarding());
-    m_offset += m_node->getRawOffset();
+    unsigned offset = m_node->getRawOffset();
+    m_offset += offset;
+    if (m_end) m_end = m_end.get() + offset;
     m_node = n;
   }
 
@@ -784,33 +1061,77 @@ unsigned Cell::getRawOffset() const {
   return m_offset;
 }
 
+boost::optional<unsigned> Cell::getRawEndOffset() const {
+  // -- resolve forwarding
+  getNode();
+  // -- return current interval end
+  return m_end;
+}
+
 unsigned Cell::getOffset() const {
   // -- adjust the offset based on the kind of node
   if (isNull() || getNode()->isOffsetCollapsed())
     return 0;
   else if (getNode()->isArray())
     return (getRawOffset() % getNode()->size());
-  else
-    return getRawOffset();
-}
-
-void Cell::pointTo(Node &n, unsigned offset) {
-  assert(!n.isForwarding());
-  // n.viewGraph();
-  m_node = &n;
-  // errs() << "dsads\n";
-  if (n.isOffsetCollapsed())
-    m_offset = 0;
-  else if (n.isArray()) {
-    assert(n.size() > 0);
-    m_offset = offset % n.size();
-  } else {
-    /// grow size as needed. allow offset to go one byte past size
-    if (offset < n.size()) n.growSize(offset);
-    m_offset = offset;
+  else {
+    unsigned offset = getRawOffset();
+    auto &cells = m_node->getCollapsedCells();
+    auto it =
+        std::find_if(cells.begin(), cells.end(),
+                     [offset](const auto &ck) { return ck.includes(offset); });
+    return (it != cells.end()) ? it->getStartOffset() : offset;
   }
 }
 
+unsigned Cell::getStartOffset() const {
+  // This is the collapsed-interval equivalent of the old Chunk start accessor:
+  // adjust for forwarding/collapse/arrays, but do not canonicalize through
+  // the node's collapsed-cell set. Otherwise a collapsed cell can find itself
+  // and recurse forever.
+  if (isNull() || getNode()->isOffsetCollapsed()) return 0;
+  if (getNode()->isArray()) return getRawOffset() % getNode()->size();
+  return getRawOffset();
+}
+
+boost::optional<unsigned> Cell::getEndOffset() const {
+  // -- adjust the interval end based on the kind of node
+  if (isNull() || getNode()->isOffsetCollapsed()) return 0;
+  auto end = getRawEndOffset();
+  if (end && getNode()->isArray()) return end.get() % getNode()->size();
+  return end;
+}
+
+void Cell::pointTo(Node &n, unsigned offset) { pointTo(n, offset, offset); }
+
+void Cell::pointTo(Node &n, unsigned start, boost::optional<unsigned> end) {
+  assert(!n.isForwarding());
+  m_node = &n;
+  if (n.isOffsetCollapsed()) {
+    m_offset = 0;
+    m_end = 0;
+  } else if (n.isArray()) {
+    assert(n.size() > 0);
+    m_offset = start % n.size();
+    m_end = end ? boost::optional<unsigned>(end.get() % n.size()) : boost::none;
+  } else {
+    /// grow size as needed. allow offset to go one byte past size
+    if (start < n.size()) n.growSize(start);
+    // a bounded interval must be covered by the node so later accesses
+    // within it stay in range
+    if (end && end.get() < n.size()) n.growSize(end.get());
+    auto &cells = m_node->getCollapsedCells();
+    auto it = std::find_if(cells.begin(), cells.end(), [start](const auto &c) {
+      return c.includes(start);
+    });
+    m_offset = (it != cells.end()) ? it->getStartOffset() : start;
+    m_end = end;
+  }
+}
+
+/*******************************************************************************
+ ******************         methods for node            ************************
+ ******************************************************************************/
 unsigned Node::getRawOffset() const {
   if (!isForwarding()) return 0;
   m_forward.getNode();
@@ -1209,16 +1530,6 @@ void Graph::clearCallSites() {
   m_callSites.clear();
 }
 
-void Cell::write(raw_ostream &o) const {
-  getNode();
-  o << "<" << m_offset << ", ";
-  if (m_node)
-    m_node->write(o);
-  else
-    o << "null";
-  o << ">";
-}
-
 void Node::dump() const {
   write(errs());
   errs() << "\n";
@@ -1231,6 +1542,33 @@ bool Graph::computeCalleeCallerMapping(const DsaCallSite &cs, Graph &calleeG,
                                        const bool reportIfSanityCheckFailed) {
   // XXX: to be removed
   const bool onlyModified = false;
+
+  DsaCallSite::const_actual_iterator AI = cs.actual_begin(),
+                                     AE = cs.actual_end();
+  for (DsaCallSite::const_formal_iterator FI = cs.formal_begin(),
+                                          FE = cs.formal_end();
+       FI != FE && AI != AE; ++FI, ++AI) {
+    const Value *fml = &*FI;
+    const Value *arg = (*AI).get();
+
+    if (calleeG.hasCell(*fml) && callerG.hasCell(*arg)) {
+      Cell &c = calleeG.mkCell(*fml, Cell());
+      if (!onlyModified || c.isModified()) {
+        Cell &nc = callerG.mkCell(*arg, Cell());
+        if (!simMap.insert(c, nc)) {
+          if (reportIfSanityCheckFailed) {
+            errs() << "ERROR 3: callee is not simulated by caller at "
+                   << *cs.getInstruction() << "\n"
+                   << "\tFormal param " << *fml << "\n"
+                   << "\tActual param " << *arg << "\n"
+                   << "\tCallee cell=" << c << "\n"
+                   << "\tCaller cell=" << nc << "\n";
+          }
+          return false;
+        }
+      }
+    }
+  }
 
   for (auto &kv : boost::make_iterator_range(calleeG.globals_begin(),
                                              calleeG.globals_end())) {
@@ -1267,41 +1605,14 @@ bool Graph::computeCalleeCallerMapping(const DsaCallSite &cs, Graph &calleeG,
       }
     }
   }
-
-  DsaCallSite::const_actual_iterator AI = cs.actual_begin(),
-                                     AE = cs.actual_end();
-  for (DsaCallSite::const_formal_iterator FI = cs.formal_begin(),
-                                          FE = cs.formal_end();
-       FI != FE && AI != AE; ++FI, ++AI) {
-    const Value *fml = &*FI;
-    const Value *arg = (*AI).get();
-
-    if (calleeG.hasCell(*fml) && callerG.hasCell(*arg)) {
-      Cell &c = calleeG.mkCell(*fml, Cell());
-      if (!onlyModified || c.isModified()) {
-        Cell &nc = callerG.mkCell(*arg, Cell());
-        if (!simMap.insert(c, nc)) {
-          if (reportIfSanityCheckFailed) {
-            errs() << "ERROR 3: callee is not simulated by caller at "
-                   << *cs.getInstruction() << "\n"
-                   << "\tFormal param " << *fml << "\n"
-                   << "\tActual param " << *arg << "\n"
-                   << "\tCallee cell=" << c << "\n"
-                   << "\tCaller cell=" << nc << "\n";
-          }
-          return false;
-        }
-      }
-    }
-  }
   return true;
 }
 
 bool Graph::computeSimulationMapping(Graph &fromG, Graph &toG,
                                      SimulationMapper &simMap,
                                      bool onlyModified) {
-  // Find a simulation relation for all globals
-  for (auto &kv : fromG.globals()) {
+  // Find a simulation relation for all function formal parameters
+  for (auto &kv : fromG.formals()) {
     Cell &c = *kv.second;
     if (!onlyModified || c.isModified()) {
       Cell &nc = toG.mkCell(*kv.first, Cell());
@@ -1309,8 +1620,8 @@ bool Graph::computeSimulationMapping(Graph &fromG, Graph &toG,
     }
   }
 
-  // Find a simulation relation for all function formal parameters
-  for (auto &kv : fromG.formals()) {
+  // Find a simulation relation for all globals
+  for (auto &kv : fromG.globals()) {
     Cell &c = *kv.second;
     if (!onlyModified || c.isModified()) {
       Cell &nc = toG.mkCell(*kv.first, Cell());
@@ -1432,7 +1743,13 @@ void Graph::write(raw_ostream &o) const {
   for (auto &kv : scalarCells) {
     const Cell *C = kv.first;
     if (kv.second.begin() != kv.second.end()) {
-      o << "cell=(" << C->getNode() << "," << C->getRawOffset() << ")\n";
+      o << "cell=(" << C->getNode() << "," << C->getRawOffset();
+      auto end = C->getRawEndOffset();
+      if (!end)
+        o << ",+oo";
+      else if (end.get() != C->getRawOffset())
+        o << "," << end.get();
+      o << ")\n";
       for (const Value *V : kv.second) {
         if (const Function *F = dyn_cast<const Function>(V)) {
           o << "\t" << F->getName() << ":" << *(F->getType()) << "\n";
@@ -1445,7 +1762,13 @@ void Graph::write(raw_ostream &o) const {
   for (auto &kv : argCells) {
     const Cell *C = kv.first;
     if (kv.second.begin() != kv.second.end()) {
-      o << "cell=(" << C->getNode() << "," << C->getRawOffset() << ")\n";
+      o << "cell=(" << C->getNode() << "," << C->getRawOffset();
+      auto end = C->getRawEndOffset();
+      if (!end)
+        o << ",+oo";
+      else if (end.get() != C->getRawOffset())
+        o << "," << end.get();
+      o << ")\n";
       for (const Argument *A : kv.second) {
         o << "\t" << *A << "\n";
       }
@@ -1454,7 +1777,13 @@ void Graph::write(raw_ostream &o) const {
   for (auto &kv : retCells) {
     const Cell *C = kv.first;
     if (kv.second.begin() != kv.second.end()) {
-      o << "cell=(" << C->getNode() << "," << C->getRawOffset() << ")\n";
+      o << "cell=(" << C->getNode() << "," << C->getRawOffset();
+      auto end = C->getRawEndOffset();
+      if (!end)
+        o << ",+oo";
+      else if (end.get() != C->getRawOffset())
+        o << "," << end.get();
+      o << ")\n";
       for (const Function *F : kv.second) {
         o << "\tret(" << F->getName() << ")\n";
       }

--- a/tests/c/idsa_cross_node.c
+++ b/tests/c/idsa_cross_node.c
@@ -1,0 +1,13 @@
+// Cross-node unification with delta alignment: cells of two distinct
+// nodes at different offsets are unified through one pointer.
+#include <stdlib.h>
+extern int nd_int(void);
+struct A { int f0; int f4; };
+struct B { int g0; int g4; int g8; };
+int main(void) {
+  struct A *a = (struct A *)malloc(sizeof(struct A));
+  struct B *b = (struct B *)malloc(sizeof(struct B));
+  int *p = nd_int() ? &a->f4 : &b->g8;
+  *p = 7;
+  return a->f0 + b->g0;
+}

--- a/tests/c/idsa_degenerate.c
+++ b/tests/c/idsa_degenerate.c
@@ -1,0 +1,18 @@
+// Degeneration: joining a cell at offset 0 with an unbounded interval
+// yields [0,+oo) — nothing outside the interval remains, so partial
+// collapse soundly degenerates to a full offset collapse.
+#include <stdlib.h>
+extern int nd_int(void);
+extern char nd_char(void);
+struct rb { int id; int size; char buf[]; };
+int main(void) {
+  int n = nd_int();
+  if (n <= 1) return 0;
+  struct rb *b = (struct rb *)malloc(sizeof(struct rb) + n);
+  b->id = 1;
+  b->size = n;
+  for (int i = 0; i < n; ++i) b->buf[i] = nd_char();
+  char *p = nd_int() ? (char *)&b->id : &b->buf[0];
+  *p = nd_char();
+  return b->id;
+}

--- a/tests/c/idsa_fam.c
+++ b/tests/c/idsa_fam.c
@@ -1,0 +1,18 @@
+// Paper overview example (redis repl_block pattern): a struct with scalar
+// fields and a trailing flexible array member indexed symbolically.
+#include <stdlib.h>
+struct rb { int id; int size; int used; char buf[]; };
+extern int nd_int(void);
+extern char nd_char(void);
+int g_id = 0;
+int main(void) {
+  int n = nd_int();
+  if (n <= 0) return 0;
+  struct rb *b = (struct rb *)malloc(sizeof(struct rb) + n);
+  b->id = g_id++;
+  b->size = n;
+  b->used = 0;
+  for (int i = 0; i < n; ++i)
+    b->buf[i] = nd_char();
+  return b->id;
+}

--- a/tests/c/idsa_same_node.c
+++ b/tests/c/idsa_same_node.c
@@ -1,0 +1,10 @@
+// Paper same-node unification example (curl if2ip pattern): one pointer
+// may address two different fields of the same object.
+extern int nd_int(void);
+struct s { int tag; int a4; int a8; int a12; };
+int main(void) {
+  struct s x = {0, 1, 2, 3};
+  int *p = nd_int() ? &x.a4 : &x.a8;
+  *p = 5;
+  return x.tag + x.a12;
+}

--- a/tests/idsa_cross_node_unify.ll
+++ b/tests/idsa_cross_node_unify.ll
@@ -1,0 +1,76 @@
+; Cross-node unification with delta alignment: cells (A,4) and (B,8)
+; are unified; node A is shifted by 4 and merged into B keeping all
+; fields distinct — no collapse with or without partial collapse.
+; RUN: %seadsa %s %butd_dsa --sea-dsa-type-aware=true --sea-dsa-partial-collapse --sea-dsa-dot --sea-dsa-dot-outdir=%T/cn.on
+; RUN: cat %T/cn.on/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=ON
+; RUN: cat %T/cn.on/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=NOCOLL
+; ON: (?=.*0:i32)(?=.*4:i32).*8:i32
+; NOCOLL-NOT: OFFSET-COLLAPSED
+
+; ModuleID = 'tests/c/idsa_cross_node.c'
+source_filename = "tests/c/idsa_cross_node.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+%struct.A = type { i32, i32 }
+%struct.B = type { i32, i32, i32 }
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  %2 = alloca ptr, align 8
+  %3 = alloca ptr, align 8
+  %4 = alloca ptr, align 8
+  store i32 0, ptr %1, align 4
+  %5 = call noalias ptr @malloc(i64 noundef 8) #3
+  store ptr %5, ptr %2, align 8
+  %6 = call noalias ptr @malloc(i64 noundef 12) #3
+  store ptr %6, ptr %3, align 8
+  %7 = call i32 @nd_int()
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %9, label %12
+
+9:                                                ; preds = %0
+  %10 = load ptr, ptr %2, align 8
+  %11 = getelementptr inbounds %struct.A, ptr %10, i32 0, i32 1
+  br label %15
+
+12:                                               ; preds = %0
+  %13 = load ptr, ptr %3, align 8
+  %14 = getelementptr inbounds %struct.B, ptr %13, i32 0, i32 2
+  br label %15
+
+15:                                               ; preds = %12, %9
+  %16 = phi ptr [ %11, %9 ], [ %14, %12 ]
+  store ptr %16, ptr %4, align 8
+  %17 = load ptr, ptr %4, align 8
+  store i32 7, ptr %17, align 4
+  %18 = load ptr, ptr %2, align 8
+  %19 = getelementptr inbounds %struct.A, ptr %18, i32 0, i32 0
+  %20 = load i32, ptr %19, align 4
+  %21 = load ptr, ptr %3, align 8
+  %22 = getelementptr inbounds %struct.B, ptr %21, i32 0, i32 0
+  %23 = load i32, ptr %22, align 4
+  %24 = add nsw i32 %20, %23
+  ret i32 %24
+}
+
+; Function Attrs: nounwind allocsize(0)
+declare noalias ptr @malloc(i64 noundef) #1
+
+declare i32 @nd_int() #2
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { nounwind allocsize(0) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { nounwind allocsize(0) }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"Ubuntu clang version 18.1.8 (++20240731024944+3b5b5c1ec4a3-1~exp1~20240731145000.144)"}

--- a/tests/idsa_partial_collapse_degenerate.ll
+++ b/tests/idsa_partial_collapse_degenerate.ll
@@ -1,0 +1,126 @@
+; Degeneration: joining a cell at offset 0 with the unbounded interval
+; of a flexible array yields [0,+oo); partial collapse then soundly
+; degenerates to a full offset collapse even with the flag enabled.
+; RUN: %seadsa %s %butd_dsa --sea-dsa-type-aware=true --sea-dsa-partial-collapse --sea-dsa-dot --sea-dsa-dot-outdir=%T/dg.on
+; RUN: cat %T/dg.on/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=ON
+; ON: OFFSET-COLLAPSED
+
+; ModuleID = 'tests/c/idsa_degenerate.c'
+source_filename = "tests/c/idsa_degenerate.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+%struct.rb = type { i32, i32, [0 x i8] }
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = alloca ptr, align 8
+  %4 = alloca i32, align 4
+  %5 = alloca ptr, align 8
+  store i32 0, ptr %1, align 4
+  %6 = call i32 @nd_int()
+  store i32 %6, ptr %2, align 4
+  %7 = load i32, ptr %2, align 4
+  %8 = icmp sle i32 %7, 1
+  br i1 %8, label %9, label %10
+
+9:                                                ; preds = %0
+  store i32 0, ptr %1, align 4
+  br label %51
+
+10:                                               ; preds = %0
+  %11 = load i32, ptr %2, align 4
+  %12 = sext i32 %11 to i64
+  %13 = add i64 8, %12
+  %14 = call noalias ptr @malloc(i64 noundef %13) #3
+  store ptr %14, ptr %3, align 8
+  %15 = load ptr, ptr %3, align 8
+  %16 = getelementptr inbounds %struct.rb, ptr %15, i32 0, i32 0
+  store i32 1, ptr %16, align 4
+  %17 = load i32, ptr %2, align 4
+  %18 = load ptr, ptr %3, align 8
+  %19 = getelementptr inbounds %struct.rb, ptr %18, i32 0, i32 1
+  store i32 %17, ptr %19, align 4
+  store i32 0, ptr %4, align 4
+  br label %20
+
+20:                                               ; preds = %31, %10
+  %21 = load i32, ptr %4, align 4
+  %22 = load i32, ptr %2, align 4
+  %23 = icmp slt i32 %21, %22
+  br i1 %23, label %24, label %34
+
+24:                                               ; preds = %20
+  %25 = call signext i8 @nd_char()
+  %26 = load ptr, ptr %3, align 8
+  %27 = getelementptr inbounds %struct.rb, ptr %26, i32 0, i32 2
+  %28 = load i32, ptr %4, align 4
+  %29 = sext i32 %28 to i64
+  %30 = getelementptr inbounds [0 x i8], ptr %27, i64 0, i64 %29
+  store i8 %25, ptr %30, align 1
+  br label %31
+
+31:                                               ; preds = %24
+  %32 = load i32, ptr %4, align 4
+  %33 = add nsw i32 %32, 1
+  store i32 %33, ptr %4, align 4
+  br label %20, !llvm.loop !6
+
+34:                                               ; preds = %20
+  %35 = call i32 @nd_int()
+  %36 = icmp ne i32 %35, 0
+  br i1 %36, label %37, label %40
+
+37:                                               ; preds = %34
+  %38 = load ptr, ptr %3, align 8
+  %39 = getelementptr inbounds %struct.rb, ptr %38, i32 0, i32 0
+  br label %44
+
+40:                                               ; preds = %34
+  %41 = load ptr, ptr %3, align 8
+  %42 = getelementptr inbounds %struct.rb, ptr %41, i32 0, i32 2
+  %43 = getelementptr inbounds [0 x i8], ptr %42, i64 0, i64 0
+  br label %44
+
+44:                                               ; preds = %40, %37
+  %45 = phi ptr [ %39, %37 ], [ %43, %40 ]
+  store ptr %45, ptr %5, align 8
+  %46 = call signext i8 @nd_char()
+  %47 = load ptr, ptr %5, align 8
+  store i8 %46, ptr %47, align 1
+  %48 = load ptr, ptr %3, align 8
+  %49 = getelementptr inbounds %struct.rb, ptr %48, i32 0, i32 0
+  %50 = load i32, ptr %49, align 4
+  store i32 %50, ptr %1, align 4
+  br label %51
+
+51:                                               ; preds = %44, %9
+  %52 = load i32, ptr %1, align 4
+  ret i32 %52
+}
+
+declare i32 @nd_int() #1
+
+; Function Attrs: nounwind allocsize(0)
+declare noalias ptr @malloc(i64 noundef) #2
+
+declare signext i8 @nd_char() #1
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { nounwind allocsize(0) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { nounwind allocsize(0) }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"Ubuntu clang version 18.1.8 (++20240731024944+3b5b5c1ec4a3-1~exp1~20240731145000.144)"}
+!6 = distinct !{!6, !7}
+!7 = !{!"llvm.loop.mustprogress"}

--- a/tests/idsa_partial_collapse_fam.ll
+++ b/tests/idsa_partial_collapse_fam.ll
@@ -1,0 +1,118 @@
+; Flexible-array-member struct (paper overview example): with partial
+; collapse the scalar fields keep distinct cells and the symbolically
+; indexed array becomes the interval [12,+oo); without the flag the
+; whole node offset-collapses.
+; RUN: %seadsa %s %butd_dsa --sea-dsa-type-aware=true --sea-dsa-partial-collapse --sea-dsa-dot --sea-dsa-dot-outdir=%T/fam.on
+; RUN: cat %T/fam.on/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=ON
+; RUN: cat %T/fam.on/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=NOCOLL
+; RUN: %seadsa %s %butd_dsa --sea-dsa-type-aware=true --sea-dsa-dot --sea-dsa-dot-outdir=%T/fam.off
+; RUN: cat %T/fam.off/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=OFF
+; ON: gold2.*(?=.*0:i32)(?=.*4:i32)(?=.*8:i32).*\[12-\+oo\]:raw
+; NOCOLL-NOT: OFFSET-COLLAPSED
+; OFF: OFFSET-COLLAPSED
+
+; ModuleID = 'tests/c/idsa_fam.c'
+source_filename = "tests/c/idsa_fam.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+%struct.rb = type { i32, i32, i32, [0 x i8] }
+
+@g_id = dso_local global i32 0, align 4
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = alloca ptr, align 8
+  %4 = alloca i32, align 4
+  store i32 0, ptr %1, align 4
+  %5 = call i32 @nd_int()
+  store i32 %5, ptr %2, align 4
+  %6 = load i32, ptr %2, align 4
+  %7 = icmp sle i32 %6, 0
+  br i1 %7, label %8, label %9
+
+8:                                                ; preds = %0
+  store i32 0, ptr %1, align 4
+  br label %41
+
+9:                                                ; preds = %0
+  %10 = load i32, ptr %2, align 4
+  %11 = sext i32 %10 to i64
+  %12 = add i64 12, %11
+  %13 = call noalias ptr @malloc(i64 noundef %12) #3
+  store ptr %13, ptr %3, align 8
+  %14 = load i32, ptr @g_id, align 4
+  %15 = add nsw i32 %14, 1
+  store i32 %15, ptr @g_id, align 4
+  %16 = load ptr, ptr %3, align 8
+  %17 = getelementptr inbounds %struct.rb, ptr %16, i32 0, i32 0
+  store i32 %14, ptr %17, align 4
+  %18 = load i32, ptr %2, align 4
+  %19 = load ptr, ptr %3, align 8
+  %20 = getelementptr inbounds %struct.rb, ptr %19, i32 0, i32 1
+  store i32 %18, ptr %20, align 4
+  %21 = load ptr, ptr %3, align 8
+  %22 = getelementptr inbounds %struct.rb, ptr %21, i32 0, i32 2
+  store i32 0, ptr %22, align 4
+  store i32 0, ptr %4, align 4
+  br label %23
+
+23:                                               ; preds = %34, %9
+  %24 = load i32, ptr %4, align 4
+  %25 = load i32, ptr %2, align 4
+  %26 = icmp slt i32 %24, %25
+  br i1 %26, label %27, label %37
+
+27:                                               ; preds = %23
+  %28 = call signext i8 @nd_char()
+  %29 = load ptr, ptr %3, align 8
+  %30 = getelementptr inbounds %struct.rb, ptr %29, i32 0, i32 3
+  %31 = load i32, ptr %4, align 4
+  %32 = sext i32 %31 to i64
+  %33 = getelementptr inbounds [0 x i8], ptr %30, i64 0, i64 %32
+  store i8 %28, ptr %33, align 1
+  br label %34
+
+34:                                               ; preds = %27
+  %35 = load i32, ptr %4, align 4
+  %36 = add nsw i32 %35, 1
+  store i32 %36, ptr %4, align 4
+  br label %23, !llvm.loop !6
+
+37:                                               ; preds = %23
+  %38 = load ptr, ptr %3, align 8
+  %39 = getelementptr inbounds %struct.rb, ptr %38, i32 0, i32 0
+  %40 = load i32, ptr %39, align 4
+  store i32 %40, ptr %1, align 4
+  br label %41
+
+41:                                               ; preds = %37, %8
+  %42 = load i32, ptr %1, align 4
+  ret i32 %42
+}
+
+declare i32 @nd_int() #1
+
+; Function Attrs: nounwind allocsize(0)
+declare noalias ptr @malloc(i64 noundef) #2
+
+declare signext i8 @nd_char() #1
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { nounwind allocsize(0) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { nounwind allocsize(0) }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"Ubuntu clang version 18.1.8 (++20240731024944+3b5b5c1ec4a3-1~exp1~20240731145000.144)"}
+!6 = distinct !{!6, !7}
+!7 = !{!"llvm.loop.mustprogress"}

--- a/tests/idsa_partial_collapse_same_node.ll
+++ b/tests/idsa_partial_collapse_same_node.ll
@@ -1,0 +1,69 @@
+; Same-node cell unification (paper if2ip example): one pointer may
+; address fields at offsets 4 and 8 of the same object; the cells merge
+; into the interval [4,8] while fields 0 and 12 stay distinct.
+; RUN: %seadsa %s %butd_dsa --sea-dsa-type-aware=true --sea-dsa-partial-collapse --sea-dsa-dot --sea-dsa-dot-outdir=%T/sn.on
+; RUN: cat %T/sn.on/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=ON
+; RUN: %seadsa %s %butd_dsa --sea-dsa-type-aware=true --sea-dsa-dot --sea-dsa-dot-outdir=%T/sn.off
+; RUN: cat %T/sn.off/main.mem.dot | OutputCheck %s -d --comment=";" --check-prefix=OFF
+; ON: gold2.*(?=.*0:i32)(?=.*12:i32).*\[4-8\]:raw
+; OFF: OFFSET-COLLAPSED
+
+; ModuleID = 'tests/c/idsa_same_node.c'
+source_filename = "tests/c/idsa_same_node.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+%struct.s = type { i32, i32, i32, i32 }
+
+@__const.main.x = private unnamed_addr constant %struct.s { i32 0, i32 1, i32 2, i32 3 }, align 4
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  %2 = alloca %struct.s, align 4
+  %3 = alloca ptr, align 8
+  store i32 0, ptr %1, align 4
+  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %2, ptr align 4 @__const.main.x, i64 16, i1 false)
+  %4 = call i32 @nd_int()
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %6, label %8
+
+6:                                                ; preds = %0
+  %7 = getelementptr inbounds %struct.s, ptr %2, i32 0, i32 1
+  br label %10
+
+8:                                                ; preds = %0
+  %9 = getelementptr inbounds %struct.s, ptr %2, i32 0, i32 2
+  br label %10
+
+10:                                               ; preds = %8, %6
+  %11 = phi ptr [ %7, %6 ], [ %9, %8 ]
+  store ptr %11, ptr %3, align 8
+  %12 = load ptr, ptr %3, align 8
+  store i32 5, ptr %12, align 4
+  %13 = getelementptr inbounds %struct.s, ptr %2, i32 0, i32 0
+  %14 = load i32, ptr %13, align 4
+  %15 = getelementptr inbounds %struct.s, ptr %2, i32 0, i32 3
+  %16 = load i32, ptr %15, align 4
+  %17 = add nsw i32 %14, %16
+  ret i32 %17
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #1
+
+declare i32 @nd_int() #2
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"Ubuntu clang version 18.1.8 (++20240731024944+3b5b5c1ec4a3-1~exp1~20240731145000.144)"}


### PR DESCRIPTION
### Motivation

When sea-dsa cannot resolve an access to a fixed offset — a symbolic GEP index into a non-array node, or a same-node unification of two different offsets — it calls `collapseOffsets()` and the *entire* node degrades to one byte-array cell. Every field the node had is merged, including fields the problematic access could never reach. Common patterns trigger this:

```c
struct rb { int id; int size; int used; char buf[]; };
...
b->buf[i] = ...;   /* symbolic index: today the whole node collapses,
                      id/size/used merge with the buffer */
```

This is expensive for clients that rely on field sensitivity (memory-region disambiguation in clam/seahorn): one flexible-array or pointer-arithmetic access poisons all neighboring scalar fields.

### What this PR does

Cells become **interval offsets**: a cell is `(node, [start, end])` where `end` may be +∞, and a node carries a set of pairwise-disjoint collapsed intervals. When collapse is needed, only the affected byte range is merged (`partialCollapseOffsets(start, end)`); fields outside the range keep their distinct cells. On the example above (with the feature on):

```
{0:i32, 4:i32, 8:i32, [12-+oo]:raw}   instead of   OFFSET-COLLAPSED
```

If intervals ever join to `[0,+oo)`, the node degenerates to exactly the old full collapse, so the old behavior is the worst case of the new one.

### Usage

Off by default. Enable with `--sea-dsa-partial-collapse`; it requires `--sea-dsa-type-aware` (interval cells key fields at type granularity) — passing it without type-awareness warns once and leaves the feature off.

### Behavior with the flag off

Byte-for-byte unchanged: with the flag off, the entire lit suite passes unmodified, and dumping `--sea-dsa-dot` for the whole test suite under `cs` and `butd-cs` produces graphs identical to current `dev18` (302/302 files, modulo pointer addresses).

### Design notes

- Well-formedness maintained: the per-node interval set stays pairwise disjoint (overlaps are absorbed on insert); a single `[0,+oo)` interval is canonicalized to the collapsed node representation.
- Offsets inside a collapsed interval canonicalize to the interval start (`Offset::getNumericOffset`), so links and accessed types stay univalent per cell.
- Symbolic GEPs use the statically known array extent when available (`[start, start+extent-stride]`) and `[start,+oo)` otherwise.
- Known limitation (documented on `m_collapsedCells`): BU/TD cloning rebuilds cells with singleton offsets, so per-cell interval *widths* are intraprocedural; only the node-level interval set survives cloning. Canonicalization still applies interprocedurally, so this is a precision limitation, not a soundness one.
- Under opaque pointers this is complementary to the current behavior: merges that used to escalate to full offset collapse (e.g. same-offset `ptr` fields with conflicting layouts) degrade to bounded intervals instead.

### Tests

- 4 new lit tests pin the feature's behaviors via DOT checks (flexible-array member, same-node interval join, cross-node unification alignment, degeneration to full collapse), with their C sources under `tests/c/`.
- Full suite: 56 passed + 2 XFAIL (clang-18/jammy-llvm18, the CI environment).

### Commit structure

1. graph: interval-offset cells as the graph representation + flag (type-aware prerequisite enforced)
2. local: interval-aware GEP handling (opaque-pointer iterator descent)
3. printer: DOT rendering of interval cells
4. tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
